### PR TITLE
Fix: Scout flush by deleting contents of index

### DIFF
--- a/src/Infrastructure/Scout/ElasticEngine.php
+++ b/src/Infrastructure/Scout/ElasticEngine.php
@@ -164,6 +164,10 @@ class ElasticEngine extends Engine
      */
     public function flush($model): void
     {
-        $this->client->indices()->flush(['index' => $model->searchableAs()]);
+        $matchAllQuery = [ 'query' => [ 'match_all' => (object)[] ] ];
+        $this->client->deleteByQuery([
+            'index' => $model->searchableAs(),
+            'body' => $matchAllQuery
+        ]);
     }
 }


### PR DESCRIPTION
Makes `php artisan scout:flush <model>` do what it should: Deletes the contents of an index