### PR TITLE
Feature: Fuzziness to matching. Ability to specify search fields

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Indices are now configured through a IndexConfiguration class and repository
+- Both Match and MultiMatch queries may now specify a 'fuzziness', the default stays 'auto'
 
 ### Changed
 - Sorting now uses the default Scout `orderBy()` method

--- a/src/Application/BuildCommand.php
+++ b/src/Application/BuildCommand.php
@@ -32,6 +32,8 @@ class BuildCommand
 
     private ?Sort $sort = null;
 
+    private ?array $defaultSearchFields = null;
+
     public static function wrap(Builder $builder): BuildCommand
     {
         $normalizedBuilder = new self();
@@ -45,6 +47,10 @@ class BuildCommand
         $normalizedBuilder->setCompound($builder->compound ?? new BoolQuery());
 
         $index = $builder->index ?: $builder->model->searchableAs();
+
+        if ($builder->model instanceof SearchableFields) {
+            $normalizedBuilder->setDefaultSearchFields($builder->model->getSearchableFields());
+        }
 
         $normalizedBuilder->setIndex($index);
 
@@ -80,6 +86,11 @@ class BuildCommand
     {
         Assert::notNull($this->index);
         return $this->index;
+    }
+
+    public function getDefaultSearchFields(): ?array
+    {
+        return $this->defaultSearchFields;
     }
 
     public function getOffset(): ?int
@@ -139,6 +150,11 @@ class BuildCommand
     public function setIndex(string $index): void
     {
         $this->index = $index;
+    }
+
+    public function setDefaultSearchFields(?array $fields): void
+    {
+        $this->defaultSearchFields = $fields;
     }
 
     public function setOffset(?int $offset): void

--- a/src/Application/BuildCommand.php
+++ b/src/Application/BuildCommand.php
@@ -33,8 +33,6 @@ class BuildCommand
 
     private ?int $limit = null;
 
-    private ?Sort $sort = null;
-
     private ?array $defaultSearchFields = null;
 
     public static function wrap(Builder $builder): BuildCommand

--- a/src/Application/Finder.php
+++ b/src/Application/Finder.php
@@ -30,7 +30,7 @@ class Finder
         $compound->addMany(QueryType::FILTER, $this->builder->getFilter());
 
         if (!empty($this->builder->getQuery())) {
-            $compound->add('must', new MultiMatch($this->builder->getQuery()));
+            $compound->add('must', new MultiMatch($this->builder->getQuery(), $this->builder->getDefaultSearchFields()));
         }
 
         foreach ($this->builder->getWhere() as $field => $value) {

--- a/src/Application/SearchableFields.php
+++ b/src/Application/SearchableFields.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Explorer\Application;
+
+interface SearchableFields
+{
+    public function getSearchableFields(): array;
+}

--- a/src/Domain/IndexManagement/IndexConfiguration.php
+++ b/src/Domain/IndexManagement/IndexConfiguration.php
@@ -17,11 +17,6 @@ final class IndexConfiguration implements IndexConfigurationInterface
         $this->name = $name;
     }
 
-    public static function empty(string $name): self
-    {
-        return new self($name);
-    }
-
     public static function create(string $name, array $properties, array $settings): self
     {
         $config = new self($name);

--- a/src/Domain/Syntax/Matching.php
+++ b/src/Domain/Syntax/Matching.php
@@ -11,14 +11,24 @@ class Matching implements SyntaxInterface
     /** @var mixed */
     private $value;
 
-    public function __construct(string $field, $value = null)
+    /** @var mixed */
+    private $fuzziness;
+
+    public function __construct(string $field, $value = null, $fuzziness = 'auto')
     {
         $this->field = $field;
         $this->value = $value;
+        $this->fuzziness = $fuzziness;
     }
 
     public function build(): array
     {
-        return ['match' => [$this->field => $this->value]];
+        $query = [ 'query' => $this->value ];
+
+        if ($this->fuzziness !== null) {
+            $query['fuzziness'] = $this->fuzziness;
+        }
+
+        return ['match' => [ $this->field => $query ] ];
     }
 }

--- a/src/Domain/Syntax/Matching.php
+++ b/src/Domain/Syntax/Matching.php
@@ -25,7 +25,7 @@ class Matching implements SyntaxInterface
     {
         $query = [ 'query' => $this->value ];
 
-        if ($this->fuzziness !== null) {
+        if (!empty($this->fuzziness)) {
             $query['fuzziness'] = $this->fuzziness;
         }
 

--- a/src/Domain/Syntax/MultiMatch.php
+++ b/src/Domain/Syntax/MultiMatch.php
@@ -30,7 +30,7 @@ class MultiMatch implements SyntaxInterface
             $query['fields'] = $this->fields;
         }
 
-        if ($this->fuzziness !== null) {
+        if (!empty($this->fuzziness)) {
             $query['fuzziness'] = $this->fuzziness;
         }
 

--- a/src/Domain/Syntax/MultiMatch.php
+++ b/src/Domain/Syntax/MultiMatch.php
@@ -9,13 +9,31 @@ class MultiMatch implements SyntaxInterface
     /** @var mixed */
     private $value;
 
-    public function __construct(string $value)
+    /** @var array|null */
+    private $fields;
+
+    /** @var mixed */
+    private $fuzziness;
+
+    public function __construct(string $value, ?array $fields = null, $fuzziness = 'auto')
     {
         $this->value = $value;
+        $this->fields = $fields;
+        $this->fuzziness = $fuzziness;
     }
 
     public function build(): array
     {
-        return ['multi_match' => ['query' => $this->value]];
+        $query = ['query' => $this->value ];
+
+        if ($this->fields !== null) {
+            $query['fields'] = $this->fields;
+        }
+
+        if ($this->fuzziness !== null) {
+            $query['fuzziness'] = $this->fuzziness;
+        }
+
+        return [ 'multi_match' => $query ];
     }
 }

--- a/tests/Unit/BuildCommandTest.php
+++ b/tests/Unit/BuildCommandTest.php
@@ -7,6 +7,7 @@ namespace JeroenG\Explorer\Tests\Unit;
 use Illuminate\Database\Eloquent\Model;
 use InvalidArgumentException;
 use JeroenG\Explorer\Application\BuildCommand;
+use JeroenG\Explorer\Application\SearchableFields;
 use JeroenG\Explorer\Domain\Compound\BoolQuery;
 use JeroenG\Explorer\Domain\Compound\CompoundSyntaxInterface;
 use JeroenG\Explorer\Domain\Syntax\Sort;
@@ -18,6 +19,8 @@ use PHPUnit\Framework\TestCase;
 class BuildCommandTest extends TestCase
 {
     private const TEST_INDEX = 'test_index';
+
+    private const TEST_SEARCHABLE_FIELDS = [':field1:', ':field2:'];
 
     public function test_it_wraps_the_default_scout_builder(): void
     {
@@ -41,6 +44,19 @@ class BuildCommandTest extends TestCase
         $subject = BuildCommand::wrap($builder);
 
         self::assertSame(self::TEST_INDEX, $subject->getIndex());
+    }
+
+    public function test_it_gets_searchable_fields(): void
+    {
+        $builder = Mockery::mock(Builder::class);
+        $builder->model = Mockery::mock(Model::class, SearchableFields::class);
+
+        $builder->index = self::TEST_INDEX;
+        $builder->model->expects('getSearchableFields')->andReturn(self::TEST_SEARCHABLE_FIELDS);
+
+        $subject = BuildCommand::wrap($builder);
+
+        self::assertSame(self::TEST_SEARCHABLE_FIELDS, $subject->getDefaultSearchFields());
     }
 
     /**

--- a/tests/Unit/Compound/BoolQueryTest.php
+++ b/tests/Unit/Compound/BoolQueryTest.php
@@ -106,7 +106,7 @@ class BoolQueryTest extends TestCase
             'bool' => [
                 'must' => [],
                 'should' => [
-                    ['match' => ['title' => 'Lorem Ipsum']]
+                    ['match' => ['title' => [ 'query' => 'Lorem Ipsum', 'fuzziness' => 'auto' ]]]
                 ],
                 'filter' => [
                     ['term' => ['published' => true, 'boost' => 1.0]],

--- a/tests/Unit/IndexManagement/IndexConfigurationTest.php
+++ b/tests/Unit/IndexManagement/IndexConfigurationTest.php
@@ -18,15 +18,6 @@ class IndexConfigurationTest extends TestCase
         self::assertSame(['settings' => 'yes please'], $config->getSettings());
     }
 
-    public function test_it_can_be_constructed_with_empty_configuration(): void
-    {
-        $config = IndexConfiguration::empty('test');
-
-        self::assertSame('test', $config->getName());
-        self::assertSame([], $config->getProperties());
-        self::assertSame([], $config->getSettings());
-    }
-
     public function test_it_can_give_the_complete_configuration(): void
     {
         $config = IndexConfiguration::create('test', ['id' => 'keyword'], ['analysis' => []]);

--- a/tests/Unit/Syntax/MatchingTest.php
+++ b/tests/Unit/Syntax/MatchingTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Explorer\Tests\Unit\Syntax;
+
+use JeroenG\Explorer\Domain\Syntax\Matching;
+use PHPUnit\Framework\TestCase;
+
+class MatchingTest extends TestCase
+{
+    public function test_it_builds_the_right_query(): void
+    {
+        $expectation = ['match' => ['test' => ['query' => 'value', 'fuzziness' => 'auto']]];
+        $subject = new Matching('test', 'value');
+
+        $result = $subject->build();
+
+        self::assertEquals($expectation, $result);
+    }
+
+    public function test_it_builds_with_fuzziness(): void
+    {
+        $expectation = ['match' => ['test' => ['query' => 'value', 'fuzziness' => 2]]];
+        $subject = new Matching('test', 'value', 2);
+
+        $result = $subject->build();
+
+        self::assertEquals($expectation, $result);
+    }
+
+    public function test_it_builds_without_fuzziness(): void
+    {
+        $expectation = ['match' => ['test' => ['query' => 'value']]];
+        $subject = new Matching('test', 'value', null);
+
+        $result = $subject->build();
+
+        self::assertEquals($expectation, $result);
+    }
+}

--- a/tests/Unit/Syntax/MultiMatchTest.php
+++ b/tests/Unit/Syntax/MultiMatchTest.php
@@ -31,6 +31,17 @@ class MultiMatchTest extends TestCase
         self::assertEquals($expected, $query);
     }
 
+    public function test_it_builds_with_empty_fields(): void
+    {
+        $subject = new MultiMatch('test', []);
+
+        $expected = ['multi_match' => ['query' => 'test', 'fuzziness' => 'auto', 'fields' => []]];
+
+        $query = $subject->build();
+
+        self::assertEquals($expected, $query);
+    }
+
     public function test_it_builds_with_fuzziness(): void
     {
         $subject = new MultiMatch('test', null, 2);

--- a/tests/Unit/Syntax/MultiMatchTest.php
+++ b/tests/Unit/Syntax/MultiMatchTest.php
@@ -13,10 +13,32 @@ class MultiMatchTest extends TestCase
     {
         $subject = new MultiMatch('test');
 
-        $expected = ['multi_match' => ['query' => 'test']];
+        $expected = ['multi_match' => ['query' => 'test', 'fuzziness' => 'auto']];
 
         $query = $subject->build();
 
-        self::assertSame($expected, $query);
+        self::assertEquals($expected, $query);
+    }
+
+    public function test_it_builds_with_fields(): void
+    {
+        $subject = new MultiMatch('test', ['test1', 'test2']);
+
+        $expected = ['multi_match' => ['query' => 'test', 'fuzziness' => 'auto', 'fields' => ['test1', 'test2']]];
+
+        $query = $subject->build();
+
+        self::assertEquals($expected, $query);
+    }
+
+    public function test_it_builds_with_fuzziness(): void
+    {
+        $subject = new MultiMatch('test', null, 2);
+
+        $expected = ['multi_match' => ['query' => 'test', 'fuzziness' => 2]];
+
+        $query = $subject->build();
+
+        self::assertEquals($expected, $query);
     }
 }


### PR DESCRIPTION
- Added fuzziness to both MultiMatch and the normal Match
- Added the ability to specify the default searchable fields
- https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness
- 