### PR TITLE
Fixes elastic syntax for rescoring and script_scoring

### DIFF
--- a/src/Domain/Query/Rescoring.php
+++ b/src/Domain/Query/Rescoring.php
@@ -32,11 +32,11 @@ class Rescoring implements SyntaxInterface
     {
         return [
             'window_size' => $this->windowSize,
-            'query_weight' => $this->queryWeight,
-            'rescore_query_weight' => $this->rescoreQueryWeight,
             'query' => [
                 'score_mode' => $this->scoreMode,
-                'rescore_query' => $this->query->build()
+                'rescore_query' => $this->query->build(),
+                'query_weight' => $this->queryWeight,
+                'rescore_query_weight' => $this->rescoreQueryWeight,
             ],
         ];
     }

--- a/src/Domain/Syntax/Compound/ScoreFunction/ScoreFunction.php
+++ b/src/Domain/Syntax/Compound/ScoreFunction/ScoreFunction.php
@@ -10,7 +10,7 @@ class ScoreFunction
 {
     private ?SyntaxInterface $filter = null;
 
-    private ?int $weight;
+    private ?int $weight = null;
 
     public function setFilter(?SyntaxInterface $filter): void
     {

--- a/src/Domain/Syntax/Compound/ScoreFunction/ScriptScoreFunction.php
+++ b/src/Domain/Syntax/Compound/ScoreFunction/ScriptScoreFunction.php
@@ -14,8 +14,10 @@ class ScriptScoreFunction extends ScoreFunction
     {
         return array_merge([
             'script_score' => [
-                'params' => $this->params,
-                'source' => $this->source,
+                'script' => [
+                    'params' => $this->params,
+                    'source' => $this->source,
+                ],
             ],
         ], parent::build());
     }

--- a/tests/Unit/Syntax/Compound/FunctionScoreTest.php
+++ b/tests/Unit/Syntax/Compound/FunctionScoreTest.php
@@ -83,8 +83,10 @@ class FunctionScoreTest extends TestCase
                 'functions' => [
                     [
                         'script_score' => [
-                            'params' => ['test' => 5 ],
-                            'source' => 'testSource'
+                            'script' => [
+                                'params' => ['test' => 5 ],
+                                'source' => 'testSource'
+                            ]
                         ],
                         'weight' => 42
                     ],

--- a/tests/Unit/Syntax/RescoringTest.php
+++ b/tests/Unit/Syntax/RescoringTest.php
@@ -18,13 +18,13 @@ class RescoringTest extends TestCase
         $result = $rescoring->build();
         self::assertEquals([
             'window_size' => 10,
-            'query_weight' => 1.0,
-            'rescore_query_weight' => 1.0,
             'query' => [
                 'score_mode' => 'total',
                 'rescore_query' => [
                     'match_all' => (object)[]
-                ]
+                ],
+                'query_weight' => 1.0,
+                'rescore_query_weight' => 1.0,
             ],
         ], $result);
     }
@@ -41,13 +41,13 @@ class RescoringTest extends TestCase
         $result = $rescoring->build();
         self::assertEquals([
             'window_size' => 1000,
-            'query_weight' => 2.0,
-            'rescore_query_weight' => 42.0,
             'query' => [
                 'score_mode' => 'multiply',
                 'rescore_query' => [
                     'match_all' => (object)[]
-                ]
+                ],
+                'query_weight' => 2.0,
+                'rescore_query_weight' => 42.0,
             ],
         ], $result);
     }


### PR DESCRIPTION
- Noticed the syntax was wrong. Function script scoring, missed the 'script' parameter
- rescoring had the `query_weight` and `rescore_query_weight` on the wrong level