### PR TITLE
allow setting size/limit

### DIFF
--- a/src/Domain/Query/Query.php
+++ b/src/Domain/Query/Query.php
@@ -37,6 +37,9 @@ class Query implements SyntaxInterface
         ];
         if ($this->hasPagination()) {
             $query['from'] = $this->offset;
+        }
+
+        if ($this->hasSize()) {
             $query['size'] = $this->limit;
         }
 
@@ -87,7 +90,12 @@ class Query implements SyntaxInterface
 
     private function hasPagination(): bool
     {
-        return !is_null($this->offset) && !is_null($this->limit);
+        return !is_null($this->offset);
+    }
+
+    private function hasSize(): bool
+    {
+        return !is_null($this->limit);
     }
 
     private function hasSort(): bool

--- a/src/Infrastructure/Scout/ScoutSearchCommandBuilder.php
+++ b/src/Infrastructure/Scout/ScoutSearchCommandBuilder.php
@@ -59,6 +59,7 @@ class ScoutSearchCommandBuilder implements SearchCommandInterface
         $normalizedBuilder->setSort(self::getSorts($builder));
         $normalizedBuilder->setFields($builder->fields ?? []);
         $normalizedBuilder->setBoolQuery($builder->compound ?? new BoolQuery());
+        $normalizedBuilder->setLimit($builder->limit);
 
         $index = $builder->index ?: $builder->model->searchableAs();
 

--- a/tests/Unit/FinderTest.php
+++ b/tests/Unit/FinderTest.php
@@ -197,6 +197,7 @@ class FinderTest extends MockeryTestCase
             ->with([
                 'index' => self::TEST_INDEX,
                 'body' => [
+                    'size' => 100,
                     'query' => [
                         'bool' => [
                             'must' => [],

--- a/tests/Unit/QueryTest.php
+++ b/tests/Unit/QueryTest.php
@@ -54,13 +54,23 @@ class QueryTest extends TestCase
         $this->query->setLimit(10);
 
         $result = $this->query->build();
-        self::assertArrayNotHasKey('size', $result);
+        self::assertArrayHasKey('size', $result);
         self::assertArrayNotHasKey('from', $result);
 
         $this->query->setLimit(null);
         $this->query->setOffset(null);
+        $result = $this->query->build();
         self::assertArrayNotHasKey('size', $result);
         self::assertArrayNotHasKey('from', $result);
+    }
+
+    public function test_it_builds_query_with_limit_alone_for_custom_total_size(): void
+    {
+        $this->query->setLimit(10);
+
+        $result = $this->query->build();
+        self::assertArrayNotHasKey('from', $result);
+        self::assertEquals(10, $result['size']);
     }
 
     public function test_it_builds_query_with_fields(): void

--- a/tests/Unit/ScoutSearchCommandBuilderTest.php
+++ b/tests/Unit/ScoutSearchCommandBuilderTest.php
@@ -200,6 +200,24 @@ class ScoutSearchCommandBuilderTest extends TestCase
         self::assertSame($input, $subject->getFields());
     }
 
+    public function test_it_can_get_a_limited_size_of_results(): void
+    {
+        $builder = Mockery::mock(Builder::class);
+        $builder->model = Mockery::mock(Model::class);
+        $builder->index = self::TEST_INDEX;
+        $builder->limit = 5;
+
+        $subject = ScoutSearchCommandBuilder::wrap($builder);
+        $query = $subject->buildQuery();
+
+        $expected = [
+            'size' => 5,
+            'query' => ['bool' => ['must' => [], 'should' => [], 'filter' => []]]
+        ];
+
+        self::assertEquals($expected, $query);
+    }
+
     public function test_it_accepts_a_custom_compound(): void
     {
         $command = new ScoutSearchCommandBuilder();


### PR DESCRIPTION
By default Elastic returns a maximum of 10 results. Laravel Scout has a `take` method to change how many results (maximum) should be returned.