### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto
+
+/.github                  export-ignore
+/tests                    export-ignore
+/.gitattributes           export-ignore
+/.gitignore               export-ignore
+/easy-coding-standard.php export-ignore
+/infection.json.dist      export-ignore
+/Makefile                 export-ignore
+/package.json             export-ignore
+/package-lock.json        export-ignore
+/phpunit.xml              export-ignore


### PR DESCRIPTION
To prevent these files to be downloaded by users of this package, we'll add a `.gitattributes` file. Composer will read this file, and ignore all files marked as `export-ignore` from the artefact downloaded from GitHub.