### PR TITLE
Feat: Added basic auth connection config

### DIFF
--- a/src/ExplorerServiceProvider.php
+++ b/src/ExplorerServiceProvider.php
@@ -42,6 +42,13 @@ class ExplorerServiceProvider extends ServiceProvider
                 );
             }
 
+            if(config()->has('explorer.connection.auth')) {
+                $client->setBasicAuthentication(
+                    config('explorer.connection.auth.username'),
+                    config('explorer.connection.auth.password')
+                );
+            }
+
             return new ElasticClientFactory($client->build());
         });
 


### PR DESCRIPTION
Edit your explorer.php config to add the basic auth credentials:

```
    'connection' => [
        'host' => 'localhost',
        'port' => '9200',
        'scheme' => 'http',

        'auth' => [
            'username' => 'your-username',
            'password' => 'password',
        ],
    ],
```

When merged, closes https://github.com/Jeroen-G/Explorer/pull/94