### PR TITLE
Leave it to Scout to set the index prefix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,10 +40,5 @@
                 "JeroenG\\Explorer\\ExplorerServiceProvider"
             ]
         }
-    },
-    "config": {
-        "allow-plugins": {
-            "infection/extension-installer": true
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,10 @@
                 "JeroenG\\Explorer\\ExplorerServiceProvider"
             ]
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "infection/extension-installer": true
+        }
     }
 }

--- a/src/Domain/IndexManagement/IndexConfiguration.php
+++ b/src/Domain/IndexManagement/IndexConfiguration.php
@@ -10,8 +10,6 @@ final class IndexConfiguration implements IndexConfigurationInterface
 {
     private string $name;
 
-    private string $scoutPrefix;
-
     private ?string $model;
 
     private array $settings = [];
@@ -20,12 +18,11 @@ final class IndexConfiguration implements IndexConfigurationInterface
 
     private ?IndexAliasConfigurationInterface $aliasConfiguration;
 
-    private function __construct(string $name, ?string $model, ?IndexAliasConfigurationInterface $aliasConfiguration = null, ?string $scoutPrefix = '')
+    private function __construct(string $name, ?string $model, ?IndexAliasConfigurationInterface $aliasConfiguration = null)
     {
         $this->model = $model;
         $this->name = $name;
         $this->aliasConfiguration = $aliasConfiguration;
-        $this->scoutPrefix = $scoutPrefix;
     }
 
     public static function create(
@@ -34,12 +31,10 @@ final class IndexConfiguration implements IndexConfigurationInterface
         array $settings,
         ?string $model = null,
         ?IndexAliasConfigurationInterface $aliasConfiguration = null,
-        ?string $scoutPrefix = '',
     ): self {
         $config = new self($name, $model, $aliasConfiguration);
         $config->properties = $properties;
         $config->settings = $settings;
-        $config->scoutPrefix = $scoutPrefix;
 
         return $config;
     }
@@ -83,16 +78,6 @@ final class IndexConfiguration implements IndexConfigurationInterface
 
     public function getWriteIndexName(): string
     {
-        return $this->isAliased() ? $this->getAliasConfiguration()->getWriteAliasName() : $this->getPrefixedName();
-    }
-
-    public function getPrefixedName(): string
-    {
-        return $this->getScoutPrefix() . $this->getName();
-    }
-
-    private function getScoutPrefix(): string
-    {
-        return $this->scoutPrefix;
+        return $this->isAliased() ? $this->getAliasConfiguration()->getWriteAliasName() : $this->getName();
     }
 }

--- a/src/Domain/IndexManagement/IndexConfigurationInterface.php
+++ b/src/Domain/IndexManagement/IndexConfigurationInterface.php
@@ -21,6 +21,4 @@ interface IndexConfigurationInterface
     public function getReadIndexName(): string;
 
     public function getWriteIndexName(): string;
-
-    public function getPrefixedName(): string;
 }

--- a/src/ExplorerServiceProvider.php
+++ b/src/ExplorerServiceProvider.php
@@ -67,7 +67,6 @@ class ExplorerServiceProvider extends ServiceProvider
             return new ElasticIndexConfigurationRepository(
                 config('explorer.indexes') ?? [],
                 config('explorer.prune_old_aliases'),
-                config('scout.prefix', '')
             );
         });
 

--- a/src/Infrastructure/Elastic/ElasticIndexAdapter.php
+++ b/src/Infrastructure/Elastic/ElasticIndexAdapter.php
@@ -28,7 +28,7 @@ final class ElasticIndexAdapter implements IndexAdapterInterface
         }
 
         $this->createIndex(
-            $indexConfiguration->getPrefixedName(),
+            $indexConfiguration->getName(),
             $indexConfiguration->getProperties(),
             $indexConfiguration->getSettings(),
         );
@@ -50,7 +50,7 @@ final class ElasticIndexAdapter implements IndexAdapterInterface
     public function delete(IndexConfigurationInterface $indexConfiguration): void
     {
         if (!$indexConfiguration->isAliased()) {
-            $this->client->indices()->delete(['index' => $indexConfiguration->getPrefixedName()]);
+            $this->client->indices()->delete(['index' => $indexConfiguration->getName()]);
             return;
         }
 
@@ -150,7 +150,6 @@ final class ElasticIndexAdapter implements IndexAdapterInterface
                 name: $index,
                 properties: [],
                 settings: [],
-                scoutPrefix: config('scout.prefix', '')
             ));
         }
     }

--- a/src/Infrastructure/IndexManagement/ElasticIndexConfigurationRepository.php
+++ b/src/Infrastructure/IndexManagement/ElasticIndexConfigurationRepository.php
@@ -46,7 +46,7 @@ class ElasticIndexConfigurationRepository implements IndexConfigurationRepositor
     public function findForIndex(string $index): IndexConfiguration
     {
         foreach ($this->getConfigurations() as $indexConfiguration) {
-            if ($indexConfiguration->getName() === $index || $indexConfiguration->getName() === $index) {
+            if ($indexConfiguration->getName() === $index) {
                 return $indexConfiguration;
             }
         }

--- a/src/Infrastructure/IndexManagement/ElasticIndexConfigurationRepository.php
+++ b/src/Infrastructure/IndexManagement/ElasticIndexConfigurationRepository.php
@@ -20,13 +20,10 @@ class ElasticIndexConfigurationRepository implements IndexConfigurationRepositor
 
     private bool $pruneOldAliases;
 
-    private string $scoutPrefix;
-
-    public function __construct(array $indexConfigurations, $pruneOldAliases = true, string $scoutPrefix = '')
+    public function __construct(array $indexConfigurations, $pruneOldAliases = true)
     {
         $this->indexConfigurations = $indexConfigurations;
         $this->pruneOldAliases = $pruneOldAliases;
-        $this->scoutPrefix = $scoutPrefix;
     }
 
     /**
@@ -49,7 +46,7 @@ class ElasticIndexConfigurationRepository implements IndexConfigurationRepositor
     public function findForIndex(string $index): IndexConfiguration
     {
         foreach ($this->getConfigurations() as $indexConfiguration) {
-            if ($indexConfiguration->getName() === $index || $indexConfiguration->getPrefixedName() === $index) {
+            if ($indexConfiguration->getName() === $index || $indexConfiguration->getName() === $index) {
                 return $indexConfiguration;
             }
         }
@@ -73,7 +70,7 @@ class ElasticIndexConfigurationRepository implements IndexConfigurationRepositor
 
         if ($class instanceof Explored) {
             $properties = $this->normalizeProperties($class->mappableAs());
-            return IndexConfiguration::create($class->searchableAs(), $properties, $settings, $index, $aliasConfiguration, $this->scoutPrefix);
+            return IndexConfiguration::create($class->searchableAs(), $properties, $settings, $index, $aliasConfiguration);
         }
 
         throw new RuntimeException(sprintf('Unable to create index %s, ensure it implements Explored', $index));
@@ -93,7 +90,6 @@ class ElasticIndexConfigurationRepository implements IndexConfigurationRepositor
             $index['settings'] ?? [],
             $model,
             $aliasConfiguration,
-            $this->scoutPrefix,
         );
     }
 

--- a/tests/Unit/IndexManagement/ElasticIndexConfigurationRepositoryTest.php
+++ b/tests/Unit/IndexManagement/ElasticIndexConfigurationRepositoryTest.php
@@ -200,34 +200,6 @@ class ElasticIndexConfigurationRepositoryTest extends MockeryTestCase
         self::assertEquals('encyclopedia', $config->getName());
     }
 
-    public function test_it_can_find_a_single_index_when_it_has_a_prefix(): void
-    {
-        $indices = [
-            'Encyclopedia' => [
-                'settings' => [],
-                'properties' => [],
-            ],
-            'encyclopedia' => [
-                'settings' => [ 'test' => true ],
-                'properties' => [
-                    'fld' => [
-                        'type' => 'text',
-                        'other' => 'This is a test'
-                    ]
-                ],
-            ],
-        ];
-
-        $repository = new ElasticIndexConfigurationRepository(indexConfigurations: $indices, scoutPrefix: 'my-prefix-');
-
-        $config = $repository->findForIndex('my-prefix-encyclopedia');
-
-        self::assertNotNull($config);
-        self::assertEquals($indices['encyclopedia']['properties'], $config->getProperties());
-        self::assertEquals($indices['encyclopedia']['settings'], $config->getSettings());
-        self::assertEquals('encyclopedia', $config->getName());
-    }
-
     public function test_it_throws_exception_if_configuration_is_not_found(): void
     {
         $repository = new ElasticIndexConfigurationRepository([]);

--- a/tests/Unit/IndexManagement/IndexConfigurationTest.php
+++ b/tests/Unit/IndexManagement/IndexConfigurationTest.php
@@ -13,13 +13,12 @@ class IndexConfigurationTest extends TestCase
 {
     public function test_it_can_create_a_configuration_with_custom_parameters(): void
     {
-        $config = IndexConfiguration::create('test', ['properties' => 'go here'], ['settings' => 'yes please'], 'model', null, 'my-prefix-');
+        $config = IndexConfiguration::create('test', ['properties' => 'go here'], ['settings' => 'yes please'], 'model', null);
 
         self::assertSame('test', $config->getName());
         self::assertSame(['properties' => 'go here'], $config->getProperties());
         self::assertSame(['settings' => 'yes please'], $config->getSettings());
         self::assertSame('model', $config->getModel());
-        self::assertSame('my-prefix-test', $config->getPrefixedName());
     }
 
     public function test_it_verifies_if_it_is_aliased(): void


### PR DESCRIPTION
![me to vincent](https://media.giphy.com/media/mEtSQlxqBtWWA/giphy.gif)

---

Prior to this change, Scout _and_ Explorer were adding a prefix to names of indices it created. This caused double prefixes in index names, and indices not to be found after updating from Explorer 2.x => 3.x. 