### PR TITLE
target indexAdapter for the scout:flush command

### DIFF
--- a/src/Infrastructure/Scout/ElasticEngine.php
+++ b/src/Infrastructure/Scout/ElasticEngine.php
@@ -196,7 +196,7 @@ class ElasticEngine extends Engine
      */
     public function flush($model): void
     {
-        $this->documentAdapter->flush($model->searchableAs());
+        $this->indexAdapter->flush($model->searchableAs());
     }
 
     public static function debug(): Debugger


### PR DESCRIPTION
php artisan scout:flush command raise an error : "Call to undefined method JeroenG\Explorer\Infrastructure\Elastic\ElasticDocumentAdapter::flush()"
We need to call indexAdapter instead of documentAdapter inElasticEngine Class