### PR TITLE
Update ElasticUpdate.php

### DIFF
--- a/src/Infrastructure/Console/ElasticUpdate.php
+++ b/src/Infrastructure/Console/ElasticUpdate.php
@@ -25,7 +25,7 @@ final class ElasticUpdate extends Command
 
         /** @var IndexConfigurationInterface $allConfigs */
         $allConfigs = is_null($index) ?
-            $indexConfigurationRepository->getConfigurations() : $indexConfigurationRepository->findForIndex($index);
+            $indexConfigurationRepository->getConfigurations() : [$indexConfigurationRepository->findForIndex($index)];
 
         foreach ($allConfigs as $config) {
             $this->updateIndex($config, $indexAdapter);


### PR DESCRIPTION
foreach expects an array.

getConfigurations() returns an array, but findForIndex( $index ) returns a single IndexConfiguration instance, so the foreach is skipped, and the index is never updated.

Let's just put that lonely indexConfiguration in an array.