### PR TITLE
Ensure index is created before mutations

### DIFF
--- a/src/Application/IndexAdapterInterface.php
+++ b/src/Application/IndexAdapterInterface.php
@@ -17,4 +17,6 @@ interface IndexAdapterInterface
     public function flush(string $index): void;
 
     public function createNewWriteIndex(IndexConfigurationInterface $indexConfiguration): string;
+
+    public function ensureIndex(IndexConfigurationInterface $indexConfiguration): void;
 }

--- a/src/Infrastructure/Elastic/ElasticIndexAdapter.php
+++ b/src/Infrastructure/Elastic/ElasticIndexAdapter.php
@@ -103,6 +103,17 @@ final class ElasticIndexAdapter implements IndexAdapterInterface
         return $indexName;
     }
 
+    public function ensureIndex(IndexConfigurationInterface $indexConfiguration): void
+    {
+        $exists = $this->client->indices()->exists([
+            'index' => $indexConfiguration->getWriteIndexName(),
+        ]);
+
+        if (!$exists) {
+            $this->create($indexConfiguration);
+        }
+    }
+
     private function makeAliasActive(IndexAliasConfigurationInterface $aliasConfiguration): void
     {
         $exists = $this->client->indices()->existsAlias(['name' => $aliasConfiguration->getAliasName()]);

--- a/src/Infrastructure/Scout/ElasticEngine.php
+++ b/src/Infrastructure/Scout/ElasticEngine.php
@@ -54,8 +54,9 @@ class ElasticEngine extends Engine
         $firstModel = $models->first();
 
         $indexConfiguration = $this->indexConfigurationRepository->findForIndex($firstModel->searchableAs());
-        $indexName = $indexConfiguration->getWriteIndexName();
+        $this->indexAdapter->ensureIndex($indexConfiguration);
 
+        $indexName = $indexConfiguration->getWriteIndexName();
         $this->documentAdapter->bulk(BulkUpdateOperation::from($models, $indexName));
     }
 
@@ -73,8 +74,9 @@ class ElasticEngine extends Engine
 
         $firstModel = $models->first();
         $indexConfiguration = $this->indexConfigurationRepository->findForIndex($firstModel->searchableAs());
-        $indexName = $indexConfiguration->getWriteIndexName();
+        $this->indexAdapter->ensureIndex($indexConfiguration);
 
+        $indexName = $indexConfiguration->getWriteIndexName();
         $models->each(function ($model) use ($indexName) {
             $this->documentAdapter->delete($indexName, $model->getScoutKey());
         });


### PR DESCRIPTION
## What has been done

- During document mutations 
  - Checks the index exists 
  - Create index if it doesn't 

## How to test

- Given a test repository.
  - Mark a model as aliased (and optionally one as not)
  - Ensure all indices are DELETED through Kibana
- Run `artisan migrate:fresh --seed` 

 ### New expected result 

- See aliases and indices setup correctly in kibana

### Old unexpected result

For aliased indices
- The write alias is created as index
- No aliases are created
- No index configuration is used

For normal indices
- No index configuration is used