### PR TITLE
Add prefix lenght field on multimatch

### DIFF
--- a/src/Domain/Syntax/MultiMatch.php
+++ b/src/Domain/Syntax/MultiMatch.php
@@ -12,11 +12,14 @@ class MultiMatch implements SyntaxInterface
 
     private mixed $fuzziness;
 
-    public function __construct(string $value, ?array $fields = null, $fuzziness = 'auto')
+    private $prefix_length;
+
+    public function __construct(string $value, ?array $fields = null, $fuzziness = 'auto', $prefix_length = 0)
     {
         $this->value = $value;
         $this->fields = $fields;
         $this->fuzziness = $fuzziness;
+        $this->prefix_length = $prefix_length;
     }
 
     public function build(): array
@@ -29,6 +32,10 @@ class MultiMatch implements SyntaxInterface
 
         if (!empty($this->fuzziness)) {
             $query['fuzziness'] = $this->fuzziness;
+        }
+
+        if (!empty($this->prefix_length)) {
+            $query['prefix_length'] = $this->prefix_length;
         }
 
         return [ 'multi_match' => $query ];

--- a/tests/Unit/Syntax/MultiMatchTest.php
+++ b/tests/Unit/Syntax/MultiMatchTest.php
@@ -52,4 +52,15 @@ class MultiMatchTest extends TestCase
 
         self::assertEquals($expected, $query);
     }
+
+    public function test_it_builds_with_prefix_lenght(): void
+    {
+        $subject = new MultiMatch('test', null, null, 2);
+
+        $expected = ['multi_match' => ['query' => 'test', 'prefix_length' => 2]];
+
+        $query = $subject->build();
+
+        self::assertEquals($expected, $query);
+    }
 }


### PR DESCRIPTION
The MultiMatch has a `prefix_lenght` field, which is the number of f initial characters which will not be “fuzzified”. It helps to reduce the number of terms which must be examined, and defaults to 0. as seen in https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#query-dsl-multi-match-query

This PR adds it to the `MultiMatch.php`. 

This is my first time contributing here, so please let me know if the PR lacks anything