### PR TITLE
Ignore 404 missing on deletes.

### DIFF
--- a/src/Infrastructure/Elastic/ElasticDocumentAdapter.php
+++ b/src/Infrastructure/Elastic/ElasticDocumentAdapter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace JeroenG\Explorer\Infrastructure\Elastic;
 
 use Elasticsearch\Client;
+use Elasticsearch\Common\Exceptions\Missing404Exception;
 use JeroenG\Explorer\Application\DocumentAdapterInterface;
 use JeroenG\Explorer\Application\Operations\Bulk\BulkOperationInterface;
 use JeroenG\Explorer\Application\Results;
@@ -37,10 +38,12 @@ final class ElasticDocumentAdapter implements DocumentAdapterInterface
 
     public function delete(string $index, $id): void
     {
-        $this->client->delete([
-            'index' => $index,
-            'id' => $id
-        ]);
+        try {
+            $this->client->delete([
+                'index' => $index,
+                'id' => $id
+            ]);
+        } catch (Missing404Exception) {}
     }
 
     public function search(SearchCommandInterface $command): Results


### PR DESCRIPTION
Fixes #159.

If a document is missing when attempting to delete, we can regard it as successful, as the document is not present in the index.

Affects users who plugin a newly created / truncated index on existing code. And users who prevent indexation on existing models.