### PR TITLE
Add source filter allong with new QueryProperties construct

### DIFF
--- a/docs/advanced-queries.md
+++ b/docs/advanced-queries.md
@@ -40,3 +40,20 @@ $results = Post::search('Self-steering')
     ->field('published_at')
     ->get();
 ```
+
+## Query properties
+
+Elastic has a multitude of options one can add to its queries. 
+
+In Explorer one can easily add these with Query Properties, you can create a class , implement the `QueryProperty` interface
+and pass it to the query. An example of this is source field filtering which we included in the SourceFilter class.
+
+```php
+use App\Models\Post;
+use JeroenG\Explorer\Domain\Query\QueryProperties\SourceFilter;
+
+$results = Post::search('Self-steering')
+    ->field('id')
+    ->property(SourceFilter::empty()->include('*.description')->exclude('*_secret'))
+    ->get();
+```

--- a/src/Domain/Query/Query.php
+++ b/src/Domain/Query/Query.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace JeroenG\Explorer\Domain\Query;
 
 use JeroenG\Explorer\Domain\Aggregations\AggregationSyntaxInterface;
+use JeroenG\Explorer\Domain\Query\QueryProperties\QueryProperty;
+use JeroenG\Explorer\Domain\Query\QueryProperties\SourceFilter;
 use JeroenG\Explorer\Domain\Syntax\Sort;
 use JeroenG\Explorer\Domain\Syntax\SyntaxInterface;
 
@@ -21,6 +23,9 @@ class Query implements SyntaxInterface
 
     /** @var Sort[] */
     private array $sort = [];
+
+    /** @var QueryProperty[]  */
+    private array $queryProperties = [];
 
     private SyntaxInterface $query;
 
@@ -67,7 +72,12 @@ class Query implements SyntaxInterface
             );
         }
 
-        return $query;
+        $allQueryProperties = array_map(
+            static fn (QueryProperty $queryProperties) => $queryProperties->build(),
+            $this->queryProperties
+        );
+
+        return array_merge($query, ...$allQueryProperties);
     }
 
     public function setOffset(?int $offset): void
@@ -93,6 +103,11 @@ class Query implements SyntaxInterface
     public function setQuery(SyntaxInterface $query): void
     {
         $this->query = $query;
+    }
+
+    public function addQueryProperties(QueryProperty ...$properties): void
+    {
+        array_push($this->queryProperties, ...$properties);
     }
 
     public function addRescoring(Rescoring $rescoring): void

--- a/src/Domain/Query/QueryProperties/QueryProperty.php
+++ b/src/Domain/Query/QueryProperties/QueryProperty.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Explorer\Domain\Query\QueryProperties;
+
+interface QueryProperty
+{
+    public function build(): array;
+}

--- a/src/Domain/Query/QueryProperties/SourceFilter.php
+++ b/src/Domain/Query/QueryProperties/SourceFilter.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Explorer\Domain\Query\QueryProperties;
+
+class SourceFilter implements QueryProperty
+{
+    /**
+     * @param string[]|null $include
+     * @param string[]|null $exclude
+     */
+    private function __construct(
+        private ?array $include = null,
+        private ?array $exclude = null,
+    ) {}
+
+    public static function empty(): self
+    {
+        return new self();
+    }
+
+    public function include(string ...$fields): self
+    {
+        $include = $this->include ?? [];
+        array_push($include, ...$fields);
+
+        return new self(
+            include: $include,
+            exclude: $this->exclude,
+        );
+    }
+
+    public function exclude(string ...$fields): self
+    {
+        $exclude = $this->exclude ?? [];
+        array_push($exclude, ...$fields);
+
+        return new self(
+            include: $this->include,
+            exclude: $exclude,
+        );
+    }
+
+    public function build(): array
+    {
+        if ($this->exclude === null && $this->include === null) {
+            return [];
+        }
+
+        $source = [];
+        if (!is_null($this->include)) {
+            $source['include'] = $this->include;
+        }
+        if (!is_null($this->exclude)) {
+            $source['exclude'] = $this->exclude;
+        }
+
+        return [
+            '_source' => $source,
+        ];
+    }
+}

--- a/src/ExplorerServiceProvider.php
+++ b/src/ExplorerServiceProvider.php
@@ -12,6 +12,7 @@ use JeroenG\Explorer\Application\IndexAdapterInterface;
 use JeroenG\Explorer\Application\IndexChangedCheckerInterface;
 use JeroenG\Explorer\Domain\Aggregations\AggregationSyntaxInterface;
 use JeroenG\Explorer\Domain\IndexManagement\IndexConfigurationRepositoryInterface;
+use JeroenG\Explorer\Domain\Query\QueryProperties\QueryProperty;
 use JeroenG\Explorer\Infrastructure\Console\ElasticSearch;
 use JeroenG\Explorer\Infrastructure\Console\ElasticUpdate;
 use JeroenG\Explorer\Infrastructure\Elastic\ElasticAdapter;
@@ -84,6 +85,9 @@ class ExplorerServiceProvider extends ServiceProvider
         Builder::macro('aggregation', function (string $name, AggregationSyntaxInterface $aggregation) {
             $this->aggregations[$name] = $aggregation;
             return $this;
+        });
+        Builder::macro('property', function (QueryProperty $queryProperty) {
+            $this->queryProperties[] = $queryProperty;
         });
     }
 

--- a/src/Infrastructure/Scout/ScoutSearchCommandBuilder.php
+++ b/src/Infrastructure/Scout/ScoutSearchCommandBuilder.php
@@ -7,6 +7,8 @@ namespace JeroenG\Explorer\Infrastructure\Scout;
 use JeroenG\Explorer\Application\SearchableFields;
 use JeroenG\Explorer\Application\SearchCommandInterface;
 use JeroenG\Explorer\Domain\Query\Query;
+use JeroenG\Explorer\Domain\Query\QueryProperties\QueryProperty;
+use JeroenG\Explorer\Domain\Query\QueryProperties\SourceFilter;
 use JeroenG\Explorer\Domain\Syntax\Compound\BoolQuery;
 use JeroenG\Explorer\Domain\Syntax\Compound\QueryType;
 use JeroenG\Explorer\Domain\Syntax\MultiMatch;
@@ -44,6 +46,8 @@ class ScoutSearchCommandBuilder implements SearchCommandInterface
 
     private ?array $defaultSearchFields = null;
 
+    private array $queryProperties = [];
+
     private BoolQuery $boolQuery;
 
     public function __construct()
@@ -66,6 +70,7 @@ class ScoutSearchCommandBuilder implements SearchCommandInterface
         $normalizedBuilder->setBoolQuery($builder->compound ?? new BoolQuery());
         $normalizedBuilder->setLimit($builder->limit);
         $normalizedBuilder->setMinimumShouldMatch($builder->minimumShouldMatch ?? null);
+        $normalizedBuilder->queryProperties = $builder->queryProperties ?? [];
 
         $index = $builder->index ?: $builder->model->searchableAs();
 
@@ -231,6 +236,7 @@ class ScoutSearchCommandBuilder implements SearchCommandInterface
         $query->setSort($this->sort);
         $query->setLimit($this->limit);
         $query->setOffset($this->offset);
+        $query->addQueryProperties(...$this->queryProperties);
 
         foreach ($this->getAggregations() as $name => $aggregation) {
             $query->addAggregation($name, $aggregation);
@@ -255,6 +261,16 @@ class ScoutSearchCommandBuilder implements SearchCommandInterface
         $query->setQuery($compound);
 
         return $query->build();
+    }
+
+    public function addQueryProperties(QueryProperty ...$queryProperties): void
+    {
+        array_push($this->queryProperties, ...$queryProperties);
+    }
+
+    public function getQueryProperties(): array
+    {
+        return $this->queryProperties;
     }
 
     /** @return Sort[] */

--- a/tests/Unit/Query/QueryProperties/SourceFilterTest.php
+++ b/tests/Unit/Query/QueryProperties/SourceFilterTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Explorer\Tests\Unit\Query\QueryProperties;
+
+use JeroenG\Explorer\Domain\Query\QueryProperties\SourceFilter;
+use PHPUnit\Framework\TestCase;
+
+final class SourceFilterTest extends TestCase
+{
+    public function test_it_defaults_empty(): void
+    {
+        $subject = SourceFilter::empty();
+
+        self::assertSame([], $subject->build());
+    }
+
+    public function test_it_adds_included_fields_in_output(): void
+    {
+        $subject = SourceFilter::empty()->include(':test-1:', ':test-2:');
+
+        self::assertSame([ '_source' => [ 'include' => [ ':test-1:', ':test-2:' ] ] ], $subject->build());
+    }
+
+    public function test_it_adds_excluded_fields_in_output(): void
+    {
+        $subject = SourceFilter::empty()->exclude(':test-1:', ':test-2:');
+
+        self::assertSame([ '_source' => [ 'exclude' => [ ':test-1:', ':test-2:' ] ] ], $subject->build());
+    }
+
+    public function test_it_adds_both_included_and_excluded_fields_in_output(): void
+    {
+        $subject = SourceFilter::empty()->exclude(':test-1:', ':test-2:')->include(':test-3:');
+
+        self::assertSame([
+            '_source' => [ 'include' => [ ':test-3:' ], 'exclude' => [ ':test-1:', ':test-2:' ] ]
+        ], $subject->build());
+    }
+
+    public function test_it_doesnt_mutate_state(): void
+    {
+        $subject = SourceFilter::empty();
+
+        self::assertNotSame($subject, $subject->include(':field:'));
+        self::assertNotSame($subject->build(), $subject->include(':field:')->build());
+
+        self::assertNotSame($subject, $subject->exclude(':field:'));
+        self::assertNotSame($subject->build(), $subject->exclude(':field:')->build());
+    }
+
+    public function test_it_adds_fields(): void
+    {
+        $subject = SourceFilter::empty();
+
+        self::assertSame(
+            [ '_source' => [ 'include' => [ ':field-1:', ':field-2:' ] ] ],
+            $subject->include(':field-1:')->include(':field-2:')->build()
+        );
+
+        self::assertSame(
+            [ '_source' => [ 'exclude' => [ ':field-1:', ':field-2:' ] ] ],
+            $subject->exclude(':field-1:')->exclude(':field-2:')->build()
+        );
+    }
+}

--- a/tests/Unit/Query/QueryTest.php
+++ b/tests/Unit/Query/QueryTest.php
@@ -2,16 +2,17 @@
 
 declare(strict_types=1);
 
-namespace JeroenG\Explorer\Tests\Unit;
+namespace JeroenG\Explorer\Tests\Unit\Query;
 
 use JeroenG\Explorer\Domain\Aggregations\TermsAggregation;
 use JeroenG\Explorer\Domain\Query\Query;
+use JeroenG\Explorer\Domain\Query\QueryProperties\SourceFilter;
 use JeroenG\Explorer\Domain\Query\Rescoring;
 use JeroenG\Explorer\Domain\Syntax\MatchAll;
 use JeroenG\Explorer\Domain\Syntax\Sort;
 use PHPUnit\Framework\TestCase;
 
-class QueryTest extends TestCase
+final class QueryTest extends TestCase
 {
     private MatchAll $syntax;
 
@@ -118,5 +119,23 @@ class QueryTest extends TestCase
                 ]
             ]
         ], $this->query->build());
+    }
+
+    public function test_it_builds_with_source_filter_query_property(): void
+    {
+        $include = [':test-1:', ':test-2:'];
+        $exclude = [':test-3:'];
+        $sourceFilter = SourceFilter::empty()->include(...$include)->exclude(...$exclude);
+
+        $this->query->addQueryProperties($sourceFilter);
+
+        self::assertEquals([
+            'query' => ['match_all' => (object)[]],
+            '_source' => [
+                'include' => $include,
+                'exclude' => $exclude,
+            ]
+        ], $this->query->build());
+
     }
 }


### PR DESCRIPTION
Fixes #144
Add QueryProperties to extend the output json from the query and allow for user defined behavior on the query itself.

Add SourceFilter as QueryProperty to allow for defining which fields are returned in the _source output