### PR TITLE
add deleteAllIndexes method to ElasticEngine

### DIFF
--- a/src/Infrastructure/Scout/ElasticEngine.php
+++ b/src/Infrastructure/Scout/ElasticEngine.php
@@ -217,4 +217,12 @@ class ElasticEngine extends Engine
         $configuration = $this->indexConfigurationRepository->findForIndex($name);
         $this->indexAdapter->delete($configuration);
     }
+
+    public function deleteAllIndexes()
+    {
+        $configs = $this->indexConfigurationRepository->getConfigurations();
+        foreach ($configs as $config) {
+            $this->indexAdapter->delete($config);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adding this method allows your elastic driver to support the `scout:delete-all-indexes` command.

## Testing
- I've omitted adding any tests since ElasticEngine isn't currently covered by phpunit
- To see in it action you can run `php artisan scout:delete-all-indexes`