### PR TITLE
Deleting aliased indexes

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,9 +5,9 @@ Use Laravel Scout import command to create and update indices.
 ```
 php artisan scout:import <model>
 ```
-For example, if your model is "App\Models\Post.php" then command would be like this:
-```php
-php artisan scout:import "App\Models\Post.php"
+For example, if your model is "App\Models\Post" then command would be like this:
+```
+php artisan scout:import "App\Models\Post"
 ```
 
 If you want to recreate an index, first make sure it's deleted and then create it.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -13,6 +13,17 @@ php artisan scout:import "App\Models\Post"
 If you want to recreate an index, first make sure it's deleted and then create it.
 Follow up with a scout import to refill the index as well.
 
+## Update Aliased Indexes
+If you are using Aliased Indexes, you should use this command instead of `scout:import`
+```
+php artisan elastic:update <index?>
+```
+You can specify an index or choose to omit it and the command will update all your indexes.
+For example, if your model is "App\Model\Post" and the index is "posts":
+```
+php artisan elastic:update posts
+```
+
 ## Delete
 ```
 php artisan scout:delete-index <model>

--- a/docs/index-aliases.md
+++ b/docs/index-aliases.md
@@ -13,7 +13,7 @@ If you wish to keep the old indices set `prune_old_aliases` to false in `config/
 ## Using aliases
 A model is only using index aliases if it implements the Aliased interface or enabled in the configuration (see [mapping](mapping.md)).
 
-After that, any time you use the `scout:import` command a new index will be created and when the insertion of models is done the alias will be pointed to the new index.
+After that, any time you use the `elastic:update` command a new index will be created and when the insertion of models is done the alias will be pointed to the new index.
 
 ```php
 <?php

--- a/src/Infrastructure/Elastic/ElasticIndexAdapter.php
+++ b/src/Infrastructure/Elastic/ElasticIndexAdapter.php
@@ -96,6 +96,7 @@ final class ElasticIndexAdapter implements IndexAdapterInterface
         $this->client->indices()->updateAliases([
             'body' => [
                 'actions' => [
+                    ['add' => ['index' => $aliasConfig->getAliasName() . '*', 'alias' => $aliasConfig->getHistoryAliasName()]],
                     ['remove' => ['index' => '*', 'alias' => $aliasConfig->getWriteAliasName()]],
                     ['add' => ['index' => $indexName, 'alias' => $aliasConfig->getWriteAliasName()]],
                 ],
@@ -130,7 +131,7 @@ final class ElasticIndexAdapter implements IndexAdapterInterface
             $this->client->indices()->updateAliases([
                 'body' => [
                     'actions' => [
-                        ['add' => ['index' => $aliasConfiguration->getAliasName() . '*', 'alias' => $aliasConfiguration->getAliasName() . '-history']],
+                        ['add' => ['index' => $aliasConfiguration->getAliasName() . '*', 'alias' => $aliasConfiguration->getHistoryAliasName()]],
                         ['remove' => ['index' => '*', 'alias' => $aliasConfiguration->getAliasName()]],
                         ['add' => ['index' => $index, 'alias' => $aliasConfiguration->getAliasName()]],
                     ],


### PR DESCRIPTION
closes #171 

## Summary
This PR contains the following changes:
- adds history tag on all new write indexes, ensuring that `scout:delete-index` can work on them from the start. This change does not conflict with the pruning feature. Before this PR, when `elastic:update` is ran twice and the history tag appears, it aliased to all existing write indexes for that model including the latest one.
- updates the docs to reflect the existence of the `elastic:update` command and its importance for actually updating index settings. `scout:import` on its own does not update the index, it will only update its content.

## Testing
- I've omitted adding any new tests since the Adapter file is not currently covered by phpunit tests..
- Running `scout:import` or `elastic:update` on newly searchable models will now create all 3 aliases
- Check that pruning still works as expected