### PR TITLE
replace builder macros with a custom scout builder

### DIFF
--- a/src/ExplorerServiceProvider.php
+++ b/src/ExplorerServiceProvider.php
@@ -11,7 +11,6 @@ use JeroenG\Explorer\Application\DocumentAdapterInterface;
 use JeroenG\Explorer\Application\IndexAdapterInterface;
 use JeroenG\Explorer\Domain\Aggregations\AggregationSyntaxInterface;
 use JeroenG\Explorer\Domain\IndexManagement\IndexConfigurationRepositoryInterface;
-use JeroenG\Explorer\Domain\Query\QueryProperties\QueryProperty;
 use JeroenG\Explorer\Infrastructure\Console\ElasticSearch;
 use JeroenG\Explorer\Infrastructure\Console\ElasticUpdate;
 use JeroenG\Explorer\Infrastructure\Elastic\ElasticClientFactory;
@@ -20,8 +19,8 @@ use JeroenG\Explorer\Infrastructure\Elastic\ElasticDocumentAdapter;
 use JeroenG\Explorer\Infrastructure\Elastic\ElasticIndexAdapter;
 use JeroenG\Explorer\Infrastructure\IndexManagement\ElasticIndexChangedChecker;
 use JeroenG\Explorer\Infrastructure\IndexManagement\ElasticIndexConfigurationRepository;
+use JeroenG\Explorer\Infrastructure\Scout\Builder;
 use JeroenG\Explorer\Infrastructure\Scout\ElasticEngine;
-use Laravel\Scout\Builder;
 use Laravel\Scout\EngineManager;
 
 /**
@@ -68,45 +67,14 @@ class ExplorerServiceProvider extends ServiceProvider
             ->needs('$defaultSettings')
             ->give(config('explorer.default_index_settings') ?? []);
 
+        $this->app->bind(\Laravel\Scout\Builder::class, Builder::class);
+
         resolve(EngineManager::class)->extend('elastic', function (Application $app) {
             return new ElasticEngine(
                 $app->make(IndexAdapterInterface::class),
                 $app->make(DocumentAdapterInterface::class),
                 $app->make(IndexConfigurationRepositoryInterface::class)
             );
-        });
-
-        Builder::macro('must', function ($must) {
-            $this->must[] = $must;
-            return $this;
-        });
-
-        Builder::macro('should', function ($should) {
-            $this->should[] = $should;
-            return $this;
-        });
-
-        Builder::macro('filter', function ($filter) {
-            $this->filter[] = $filter;
-            return $this;
-        });
-
-        Builder::macro('field', function (string $field) {
-            $this->fields[] = $field;
-            return $this;
-        });
-
-        Builder::macro('newCompound', function ($compound) {
-            $this->compound = $compound;
-            return $this;
-        });
-
-        Builder::macro('aggregation', function (string $name, AggregationSyntaxInterface $aggregation) {
-            $this->aggregations[$name] = $aggregation;
-            return $this;
-        });
-        Builder::macro('property', function (QueryProperty $queryProperty) {
-            $this->queryProperties[] = $queryProperty;
         });
     }
 

--- a/src/Infrastructure/Scout/Builder.php
+++ b/src/Infrastructure/Scout/Builder.php
@@ -7,22 +7,23 @@ namespace JeroenG\Explorer\Infrastructure\Scout;
 use JeroenG\Explorer\Application\Paginator;
 use JeroenG\Explorer\Domain\Aggregations\AggregationSyntaxInterface;
 use JeroenG\Explorer\Domain\Query\QueryProperties\QueryProperty;
+use JeroenG\Explorer\Domain\Syntax\Compound\BoolQuery;
 
 class Builder extends \Laravel\Scout\Builder
 {
-    public array $must;
+    public array $must = [];
 
-    public array $should;
+    public array $should = [];
 
-    public array $filter;
+    public array $filter = [];
 
-    public array $fields;
+    public array $fields = [];
 
-    public array $compound;
+    public ?BoolQuery $compound = null;
 
-    public array $aggregations;
+    public array $aggregations = [];
 
-    public array $queryProperties;
+    public array $queryProperties = [];
 
     public function must($must): self
     {
@@ -48,7 +49,7 @@ class Builder extends \Laravel\Scout\Builder
         return $this;
     }
 
-    public function newCompound($compound): self
+    public function newCompound(?BoolQuery $compound): self
     {
         $this->compound = $compound;
         return $this;

--- a/src/Infrastructure/Scout/Builder.php
+++ b/src/Infrastructure/Scout/Builder.php
@@ -9,6 +9,9 @@ use JeroenG\Explorer\Domain\Aggregations\AggregationSyntaxInterface;
 use JeroenG\Explorer\Domain\Query\QueryProperties\QueryProperty;
 use JeroenG\Explorer\Domain\Syntax\Compound\BoolQuery;
 
+/**
+ * @internal This custom scout builder is not part of the public API, extend it at your own risk.
+ */
 class Builder extends \Laravel\Scout\Builder
 {
     public array $must = [];

--- a/src/Infrastructure/Scout/Builder.php
+++ b/src/Infrastructure/Scout/Builder.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Explorer\Infrastructure\Scout;
+
+use JeroenG\Explorer\Application\Paginator;
+use JeroenG\Explorer\Domain\Aggregations\AggregationSyntaxInterface;
+use JeroenG\Explorer\Domain\Query\QueryProperties\QueryProperty;
+
+class Builder extends \Laravel\Scout\Builder
+{
+    public array $must;
+
+    public array $should;
+
+    public array $filter;
+
+    public array $fields;
+
+    public array $compound;
+
+    public array $aggregations;
+
+    public array $queryProperties;
+
+    public function must($must): self
+    {
+        $this->must[] = $must;
+        return $this;
+    }
+
+    public function should($should): self
+    {
+        $this->should[] = $should;
+        return $this;
+    }
+
+    public function filter($filter): self
+    {
+        $this->filter[] = $filter;
+        return $this;
+    }
+
+    public function field(string $field): self
+    {
+        $this->fields[] = $field;
+        return $this;
+    }
+
+    public function newCompound($compound): self
+    {
+        $this->compound = $compound;
+        return $this;
+    }
+
+    public function aggregation(string $name, AggregationSyntaxInterface $aggregation): self
+    {
+        $this->aggregations[$name] = $aggregation;
+        return $this;
+    }
+
+    public function property(QueryProperty $queryProperty): self
+    {
+        $this->queryProperties[] = $queryProperty;
+        return $this;
+    }
+}

--- a/src/Infrastructure/Scout/ElasticEngine.php
+++ b/src/Infrastructure/Scout/ElasticEngine.php
@@ -63,7 +63,7 @@ class ElasticEngine extends Engine
     /**
      * Remove the given model from the index.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @param  \Illuminate\Database\Eloquent\Collection<array-key, Model&Explored>  $models
      * @return void
      */
     public function delete($models): void

--- a/tests/Support/Models/TestModelWithAliased.php
+++ b/tests/Support/Models/TestModelWithAliased.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace JeroenG\Explorer\Tests\Support\Models;
 
+use Illuminate\Database\Eloquent\Model;
 use JeroenG\Explorer\Application\Aliased;
 use JeroenG\Explorer\Application\Explored;
 
-class TestModelWithAliased implements Explored, Aliased
+class TestModelWithAliased extends Model implements Explored, Aliased
 {
     public function getScoutKey(): string
     {

--- a/tests/Support/Models/TestModelWithPrepare.php
+++ b/tests/Support/Models/TestModelWithPrepare.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace JeroenG\Explorer\Tests\Support\Models;
 
+use Illuminate\Database\Eloquent\Model;
 use JeroenG\Explorer\Application\BePrepared;
 use JeroenG\Explorer\Application\Explored;
 
-class TestModelWithPrepare implements Explored, BePrepared
+class TestModelWithPrepare extends Model implements Explored, BePrepared
 {
     public function getScoutKey(): string
     {

--- a/tests/Support/Models/TestModelWithSettings.php
+++ b/tests/Support/Models/TestModelWithSettings.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace JeroenG\Explorer\Tests\Support\Models;
 
+use Illuminate\Database\Eloquent\Model;
 use JeroenG\Explorer\Application\Explored;
 use JeroenG\Explorer\Application\IndexSettings;
 
-class TestModelWithSettings implements Explored, IndexSettings
+class TestModelWithSettings extends Model implements Explored, IndexSettings
 {
     public function getScoutKey(): string
     {

--- a/tests/Support/Models/TestModelWithoutSettings.php
+++ b/tests/Support/Models/TestModelWithoutSettings.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace JeroenG\Explorer\Tests\Support\Models;
 
+use Illuminate\Database\Eloquent\Model;
 use JeroenG\Explorer\Application\Explored;
 
-class TestModelWithoutSettings implements Explored
+class TestModelWithoutSettings extends Model implements Explored
 {
     public function getScoutKey(): string
     {

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Explorer\Tests\Unit;
+
+use JeroenG\Explorer\Domain\Aggregations\TermsAggregation;
+use JeroenG\Explorer\Domain\Query\QueryProperties\TrackTotalHits;
+use JeroenG\Explorer\Domain\Syntax\Compound\BoolQuery;
+use JeroenG\Explorer\Domain\Syntax\MultiMatch;
+use JeroenG\Explorer\Domain\Syntax\Term;
+use JeroenG\Explorer\Domain\Syntax\Terms;
+use JeroenG\Explorer\Infrastructure\Scout\Builder;
+use JeroenG\Explorer\Tests\Support\Models\TestModelWithAliased;
+use PHPUnit\Framework\TestCase;
+
+class BuilderTest extends TestCase
+{
+    public function test_it_can_add_to_builder_bool_query_properties(): void
+    {
+        $builder = new Builder(new TestModelWithAliased(), '');
+
+        $this->assertEmpty($builder->should);
+        $this->assertEmpty($builder->must);
+        $this->assertEmpty($builder->filter);
+        $this->assertEmpty($builder->fields);
+        $this->assertEmpty($builder->queryProperties);
+
+        $should = new Term('field', 'value');
+        $must = new MultiMatch('search');
+        $filter = new Terms('tags', ['a', 'b']);
+
+        $builder->should($should);
+        $builder->must($must);
+        $builder->filter($filter);
+        $builder->field('body')->field('field')->field('tags');
+        $builder->property(TrackTotalHits::all());
+
+        $this->assertContains($should, $builder->should);
+        $this->assertContains($must, $builder->must);
+        $this->assertContains($filter, $builder->filter);
+        $this->assertCount(3, $builder->fields);
+        $this->assertCount(1, $builder->queryProperties);
+    }
+
+    public function test_it_can_add_to_builder_aggregation_property(): void
+    {
+        $builder = new Builder(new TestModelWithAliased(), '');
+
+        $this->assertEmpty($builder->aggregations);
+
+        $aggregation = new TermsAggregation(':field:');
+        $builder->aggregation('field', $aggregation);
+
+        $this->assertContains($aggregation, $builder->aggregations);
+    }
+
+    public function test_it_can_add_to_builder_compound_property(): void
+    {
+        $builder = new Builder(new TestModelWithAliased(), '');
+
+        $this->assertNull($builder->compound);
+
+        $boolQuery = new BoolQuery();
+        $builder->newCompound($boolQuery);
+
+        $this->assertSame($boolQuery, $builder->compound);
+    }
+}


### PR DESCRIPTION
## Summary
This PR swaps out Scout Builder macro calls in the Service Provider with a custom scout builder implementation. 

This serves to clean up the service provider but also improves type hinting in IDEs. Furthermore, it lets package users swap in their own Builder with any additional changes they may need.

# Testing
- Attempt to use any of the explorer specific methods (eg: must / should / filter) covered in the BuiderTest file