### PR TITLE
fix scout where & add whereIn support

### DIFF
--- a/tests/Unit/FinderTest.php
+++ b/tests/Unit/FinderTest.php
@@ -83,13 +83,14 @@ class FinderTest extends MockeryTestCase
                             'must' => [
                                 ['match' => ['title' => [ 'query' => 'Lorem Ipsum', 'fuzziness' => 'auto']]],
                                 ['multi_match' => ['query' => 'fuzzy search', 'fuzziness' => 'auto']],
-                                ['term' => ['subtitle' => [ 'value' => 'Dolor sit amet', 'boost' => 1.0]]]
                             ],
                             'should' => [
                                 ['match' => ['text' => [ 'query' => 'consectetur adipiscing elit', 'fuzziness' => 'auto']]],
                             ],
                             'filter' => [
                                 ['term' => ['published' => [ 'value' => true, 'boost' => 1.0]]],
+                                ['term' => ['subtitle' => [ 'value' => 'Dolor sit amet', 'boost' => 1.0]]],
+                                ['terms' => ['tags' => ['t1', 't2'], 'boost' => 1.0]],
                             ],
                         ],
                     ],
@@ -110,7 +111,8 @@ class FinderTest extends MockeryTestCase
         $builder->setMust([new Matching('title', 'Lorem Ipsum')]);
         $builder->setShould([new Matching('text', 'consectetur adipiscing elit')]);
         $builder->setFilter([new Term('published', true)]);
-        $builder->setWhere(['subtitle' => 'Dolor sit amet']);
+        $builder->setWheres(['subtitle' => 'Dolor sit amet']);
+        $builder->setWhereIns(['tags' => ['t1', 't2']]);
         $builder->setQuery('fuzzy search');
 
         $subject = new Finder($client, $builder);

--- a/tests/Unit/ScoutSearchCommandBuilderTest.php
+++ b/tests/Unit/ScoutSearchCommandBuilderTest.php
@@ -76,7 +76,7 @@ class ScoutSearchCommandBuilderTest extends TestCase
         $builder = Mockery::mock(Builder::class);
         $builder->index = self::TEST_INDEX;
 
-        $setter = mb_strtolower($method);
+        $setter = lcfirst($method);
         $getter = "get{$method}";
 
         $builder->$setter = $expected;
@@ -107,7 +107,8 @@ class ScoutSearchCommandBuilderTest extends TestCase
             ['Must', [new Term('field', 'value')]],
             ['Should', [new Term('field', 'value')]],
             ['Filter', [new Term('field', 'value')]],
-            ['Where', ['field' => 'value']],
+            ['Wheres', ['field' => 'value']],
+            ['WhereIns', ['field' => ['value1', 'value2']]],
             ['Query', 'Lorem Ipsum'],
         ];
     }
@@ -311,7 +312,7 @@ class ScoutSearchCommandBuilderTest extends TestCase
         $subject->setFilter([$term]);
         $subject->setShould([$term]);
         $subject->setBoolQuery($boolQuery);
-        $subject->setWhere([ $whereField => $whereValue ]);
+        $subject->setWheres([ $whereField => $whereValue ]);
         $subject->setMinimumShouldMatch('50%');
 
         $boolQuery->expects('clone')->andReturn($boolQuery);
@@ -329,7 +330,7 @@ class ScoutSearchCommandBuilderTest extends TestCase
 
         $boolQuery->expects('add')
             ->withArgs(function (string $type, SyntaxInterface $query) {
-                return $type === 'must'
+                return $type === 'filter'
                     && $query instanceof Term;
             });
 


### PR DESCRIPTION
## Summary

Noticed that `ScoutSearchCommandBuilder` was using `$builder->where` which doesn't exist. Instead, Laravel\Scout\Builder has the public fields `wheres` and `whereIns`. 

This PR makes the following changes:

- fix the intended support for `\Laravel\Scout\Builder::where('field', 'value')` calls 
- adds support for `\Laravel\Scout\Builder::whereIn('field', ['1', '2'])` calls
- `ScoutSearchCommandBuilder::buildQuery()` now adds these where and whereIn clauses to the bool query `filter` section instead of `must`. In theory filter clauses are [cacheable in ES](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html) and we don't really care about boosting scores here.

## Testing Checklist
- Updated tests to use changed method names & the change from `must` to `filter`
- Added coverage for the new whereIn usage