### PR TITLE
add regexp query syntax

### DIFF
--- a/src/Domain/Syntax/RegExp.php
+++ b/src/Domain/Syntax/RegExp.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Explorer\Domain\Syntax;
+
+class RegExp implements SyntaxInterface
+{
+    private string $field;
+    
+    private ?string $value;
+
+    private string $flags;
+
+    private bool $insensitive;
+
+    public function __construct(string $field, string $value = null, string $flags = 'ALL', bool $insensitive = false)
+    {
+        $this->field = $field;
+        $this->value = $value;
+        $this->flags = $flags;
+        $this->insensitive = $insensitive;
+    }
+
+    public function build(): array
+    {
+        return ['regexp' => [
+            $this->field => [
+                'value' => $this->value,
+                'flags' => $this->flags,
+                'case_insensitive' => $this->insensitive,
+            ],
+        ]];
+    }
+}

--- a/tests/Unit/Syntax/RegExpTest.php
+++ b/tests/Unit/Syntax/RegExpTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Explorer\Tests\Unit\Syntax;
+
+use InvalidArgumentException;
+use JeroenG\Explorer\Domain\Syntax\RegExp;
+use JeroenG\Explorer\Domain\Syntax\Terms;
+use PHPUnit\Framework\TestCase;
+
+class RegExpTest extends TestCase
+{
+    public function test_it_builds_the_right_query(): void
+    {
+        $subject = new RegExp('test', '[aA].+');
+
+        $expected = ['regexp' => ['test' => ['value' => '[aA].+', 'flags' => 'ALL', 'case_insensitive' => false]]];
+
+        $query = $subject->build();
+
+        self::assertSame($expected, $query);
+    }
+}


### PR DESCRIPTION
### Summary
Adds regexp query syntax and a test for it. 

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html

### Testing
- RegExpTest