### PR TITLE
Adds a config key to pass default index settings to all indices

### DIFF
--- a/config/explorer.php
+++ b/config/explorer.php
@@ -15,6 +15,16 @@ return [
     ],
 
     /**
+     * The default index settings used when creating a new index. You can override these settings
+     * on a per-index basis by implementing the IndexSettings interface on your model or defining
+     * them in the index configuration below.
+     */
+    'default_index_settings' => [
+        //'index' => [],
+        //'analysis' => [],
+    ],
+
+    /**
      * An index may be defined on an Eloquent model or inline below. A more in depth explanation
      * of the mapping possibilities can be found in the documentation of Explorer's repository.
      */

--- a/docs/index-settings.md
+++ b/docs/index-settings.md
@@ -4,6 +4,7 @@ However, if for example you want to define more advanced Elasticsearch settings 
 
 Be aware that any time you change the index settings, you need to [recreate](commands.md) the index.
 
+## Using models
 To start using index settings, we will expand on the Post model with an `indexSettings` function to set an analyzer.
 
 ```php
@@ -52,6 +53,7 @@ class Post extends Model implements Explored, IndexSettings
 
 If you want to create an analyzer object-oriented, [continue reading here](text-analysis.md).
 
+## Using configuration arrays
 If you want to use the configuration array notation (see [mapping](mapping.md)), you may add the settings as follows:
 
 ```php
@@ -75,6 +77,28 @@ return [
                 'created_at' => 'date',
                 'published' => 'boolean',
                 'author' => 'nested',
+            ],
+        ],
+    ],
+];
+```
+
+## Default index settings
+If you want to set default index settings for all your indices, you can do so by adding the `default_index_settings` key to your configuration file:
+
+```php
+return [
+    'default_index_settings' => [
+        'index' => [
+            'max_result_window' => 100000,
+        ],
+        'analysis' => [
+            'analyzer' => [
+                'standard_lowercase' => [
+                    'type' => 'custom',
+                    'tokenizer' => 'standard',
+                    'filter' => ['lowercase'],
+                ],
             ],
         ],
     ],

--- a/src/ExplorerServiceProvider.php
+++ b/src/ExplorerServiceProvider.php
@@ -64,6 +64,10 @@ class ExplorerServiceProvider extends ServiceProvider
             ->needs('$pruneOldAliases')
             ->give(config('explorer.prune_old_aliases') ?? true);
 
+        $this->app->when(ElasticIndexConfigurationRepository::class)
+            ->needs('$defaultSettings')
+            ->give(config('explorer.default_index_settings') ?? []);
+
         resolve(EngineManager::class)->extend('elastic', function (Application $app) {
             return new ElasticEngine(
                 $app->make(IndexAdapterInterface::class),


### PR DESCRIPTION
## Summary
This PR adds a new config key for setting the default index settings we should apply to all new indices unless they have their own specific per index settings.

This is something I find useful when I needed to specify a higher `max_results_window` for every one of my indices. They do share the same Searchable trait however I wasn't a fan of adding yet another interface (IndexSettings) to each and every one of my models. Instead I modified `ElasticIndexConfigurationRepository` to support a new default option that I can reuse. 

Tests and updated documentation are included in this PR as well. 

## Testing
1. Default index settings never override an index's own settings, if they are provided
2. Default index settings are applied both to model and array based indices
3. Default index settings key can be ignored or even missing, for backwards compatibility
