### PR TITLE
Disable PHPStan on PHP8.3 as it trigger OOM errors on any limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,5 @@ jobs:
 
       - name: PHPStan analysis
         run: vendor/bin/phpstan analyse
+        # PHPStan seems to reach any memory limit set when using php 8.3. Disabling for now
+        if: ${{ matrix.experimental == false }}


### PR DESCRIPTION
For some reason PHPStan in combination with PHP 8.3 uses an extreme amount of memory. I cannot find any open issues for it, but as PHP 8.3 is not released yet, lets disable it for now.