### PR TITLE
fix(#193): make sure to update aliases only on the intended index

### DIFF
--- a/src/Infrastructure/Elastic/ElasticIndexAdapter.php
+++ b/src/Infrastructure/Elastic/ElasticIndexAdapter.php
@@ -97,7 +97,7 @@ final class ElasticIndexAdapter implements IndexAdapterInterface
             'body' => [
                 'actions' => [
                     ['add' => ['index' => $aliasConfig->getAliasName() . '*', 'alias' => $aliasConfig->getHistoryAliasName()]],
-                    ['remove' => ['index' => '*', 'alias' => $aliasConfig->getWriteAliasName()]],
+                    ['remove' => ['index' => $aliasConfig->getAliasName() . '*', 'alias' => $aliasConfig->getWriteAliasName()]],
                     ['add' => ['index' => $indexName, 'alias' => $aliasConfig->getWriteAliasName()]],
                 ],
             ],
@@ -121,6 +121,7 @@ final class ElasticIndexAdapter implements IndexAdapterInterface
     {
         $exists = $this->client->indices()->existsAlias(['name' => $aliasConfiguration->getAliasName()]);
         $index = $this->getWriteIndexName($aliasConfiguration);
+        $alias = $aliasConfiguration->getAliasName();
 
         if (!$exists) {
             $this->client->indices()->putAlias([
@@ -131,8 +132,8 @@ final class ElasticIndexAdapter implements IndexAdapterInterface
             $this->client->indices()->updateAliases([
                 'body' => [
                     'actions' => [
-                        ['add' => ['index' => $aliasConfiguration->getAliasName() . '*', 'alias' => $aliasConfiguration->getHistoryAliasName()]],
-                        ['remove' => ['index' => '*', 'alias' => $aliasConfiguration->getAliasName()]],
+                        ['add' => ['index' => $alias . '*', 'alias' => $aliasConfiguration->getHistoryAliasName()]],
+                        ['remove' => ['index' => $alias . '*', 'alias' => $aliasConfiguration->getAliasName()]],
                         ['add' => ['index' => $index, 'alias' => $aliasConfiguration->getAliasName()]],
                     ],
                 ],


### PR DESCRIPTION
## Description

Closes #193, which is an issue with the updating aliases requests accidentally looking up an internal opensearch index and failing a permissions check. 

## Testing
You'd need an ES instance with security plugin enabled and some sort of internal index that shouldn't be modified.
In my case, I was running OpenSearch 2.5 and that index was called `.opendistro_security`. SSL verification was disabled in explorer's connection config.