### PR TITLE
fix: move builder binding from provider boot to bindings array

### DIFF
--- a/src/ExplorerServiceProvider.php
+++ b/src/ExplorerServiceProvider.php
@@ -39,6 +39,7 @@ class ExplorerServiceProvider extends ServiceProvider
         IndexAdapterInterface::class => ElasticIndexAdapter::class,
         DocumentAdapterInterface::class => ElasticDocumentAdapter::class,
         IndexConfigurationRepositoryInterface::class => ElasticIndexConfigurationRepository::class,
+        \Laravel\Scout\Builder::class => Builder::class,
     ];
 
     public function boot(): void
@@ -66,8 +67,6 @@ class ExplorerServiceProvider extends ServiceProvider
         $this->app->when(ElasticIndexConfigurationRepository::class)
             ->needs('$defaultSettings')
             ->give(config('explorer.default_index_settings') ?? []);
-
-        $this->app->bind(\Laravel\Scout\Builder::class, Builder::class);
 
         resolve(EngineManager::class)->extend('elastic', function (Application $app) {
             return new ElasticEngine(


### PR DESCRIPTION
Tiny PR that cleans up the Service Provider. 

Rebinding the Scout Builder inside the boot method does not follow Laravel conventions so I'm moving it up to the bindings array with the rest of the bindings. 

The conditional bindings (when) remain untouched. 