### PR TITLE
fix: composer license

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "jeroen-g/explorer",
     "description": "Next-gen Elasticsearch driver for Laravel Scout.",
-    "license": "EUPL-1.2",
+    "license": "MIT",
     "authors": [
         {
             "name": "Jeroen",


### PR DESCRIPTION
According to https://github.com/Jeroen-G/Explorer/blob/master/license.md explorer has the MIT license.