### PR TITLE
add search callback process #200

### DIFF
--- a/src/Infrastructure/Scout/ScoutSearchCommandBuilder.php
+++ b/src/Infrastructure/Scout/ScoutSearchCommandBuilder.php
@@ -83,6 +83,10 @@ class ScoutSearchCommandBuilder implements SearchCommandInterface
 
         $normalizedBuilder->setIndex($index);
 
+        if($builder->callback){
+            call_user_func($builder->callback, $normalizedBuilder);
+        }
+
         return $normalizedBuilder;
     }
 
@@ -288,6 +292,16 @@ class ScoutSearchCommandBuilder implements SearchCommandInterface
     public function getQueryProperties(): array
     {
         return $this->queryProperties;
+    }
+
+    public function getLimit(): ?int
+    {
+        return $this->limit;
+    }
+
+    public function getOffset(): ?int
+    {
+        return $this->offset;
     }
 
     /** @return Sort[] */

--- a/tests/Unit/ScoutSearchCommandBuilderTest.php
+++ b/tests/Unit/ScoutSearchCommandBuilderTest.php
@@ -412,4 +412,23 @@ class ScoutSearchCommandBuilderTest extends TestCase
 
         self::assertSame($builder->queryProperties, $subject->getQueryProperties());
     }
+
+    public function test_it_call_builder_callback(): void
+    {
+        $builder = Mockery::mock(Builder::class);
+        $builder->model = Mockery::mock(Model::class);
+        $builder->index = self::TEST_INDEX;
+        $limit  = rand(1, 1000);
+        $offset = rand(1, 1000);
+
+        $builder->callback = function (ScoutSearchCommandBuilder $builder) use ($limit, $offset){
+            $builder->setLimit($limit);
+            $builder->setOffset($offset);
+        };
+
+        $subject = ScoutSearchCommandBuilder::wrap($builder);
+
+        self::assertSame($limit, $subject->getLimit());
+        self::assertSame($offset, $subject->getOffset());
+    }
 }


### PR DESCRIPTION
Ability to modify query builder before search in elastic. Setting this callback:

https://laravel.com/docs/10.x/scout#customizing-engine-searches 