### PR TITLE
Update index alias on queue

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: src/Infrastructure/Console/ElasticSearch.php
 
 		-
-			message: "#^Argument of an invalid type JeroenG\\\\Explorer\\\\Domain\\\\IndexManagement\\\\IndexConfigurationInterface supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: src/Infrastructure/Console/ElasticUpdate.php
-
-		-
 			message: "#^Call to an undefined method JeroenG\\\\Explorer\\\\Domain\\\\IndexManagement\\\\IndexConfigurationInterface\\:\\:getAliasConfiguration\\(\\)\\.$#"
 			count: 1
 			path: src/Infrastructure/Elastic/ElasticIndexAdapter.php

--- a/src/Domain/IndexManagement/Job/UpdateIndexAlias.php
+++ b/src/Domain/IndexManagement/Job/UpdateIndexAlias.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace JeroenG\Explorer\Domain\IndexManagement\Job;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use JeroenG\Explorer\Application\IndexAdapterInterface;
+use JeroenG\Explorer\Domain\IndexManagement\IndexConfigurationRepositoryInterface;
+
+class UpdateIndexAlias implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public string $index)
+    {
+    }
+
+    public function handle(
+        IndexAdapterInterface $indexAdapter,
+        IndexConfigurationRepositoryInterface $indexConfigurationRepository
+    ): void {
+        $indexConfiguration = $indexConfigurationRepository->findForIndex($this->index);
+        $indexAdapter->pointToAlias($indexConfiguration);
+    }
+}

--- a/src/Infrastructure/Console/ElasticUpdate.php
+++ b/src/Infrastructure/Console/ElasticUpdate.php
@@ -10,6 +10,7 @@ use JeroenG\Explorer\Application\IndexAdapterInterface;
 use JeroenG\Explorer\Domain\IndexManagement\AliasedIndexConfiguration;
 use JeroenG\Explorer\Domain\IndexManagement\IndexConfigurationInterface;
 use JeroenG\Explorer\Domain\IndexManagement\IndexConfigurationRepositoryInterface;
+use JeroenG\Explorer\Domain\IndexManagement\Job\UpdateIndexAlias;
 
 final class ElasticUpdate extends Command
 {
@@ -51,6 +52,11 @@ final class ElasticUpdate extends Command
             }
         }
 
-        $indexAdapter->pointToAlias($indexConfiguration);
+        $modelClassName = $indexConfiguration->getModel();
+        $model = new $modelClassName();
+
+        dispatch(new UpdateIndexAlias($indexConfiguration->getName()))
+            ->onConnection($model->syncWithSearchUsing())
+            ->onQueue($model->syncWithSearchUsingQueue());
     }
 }

--- a/tests/Support/Models/SyncableModel.php
+++ b/tests/Support/Models/SyncableModel.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Explorer\Tests\Support\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use JeroenG\Explorer\Application\Aliased;
+use JeroenG\Explorer\Application\Explored;
+use Laravel\Scout\Searchable;
+
+class SyncableModel extends Model
+{
+    public function syncWithSearchUsingQueue(): string
+    {
+        return ':queue:';
+    }
+
+    public function syncWithSearchUsing(): string
+    {
+        return ':connection:';
+    }
+}

--- a/tests/Unit/IndexManagement/Job/UpdateIndexAliasTest.php
+++ b/tests/Unit/IndexManagement/Job/UpdateIndexAliasTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Explorer\Tests\Unit\IndexManagement\Job;
+
+use JeroenG\Explorer\Application\IndexAdapterInterface;
+use JeroenG\Explorer\Domain\IndexManagement\DirectIndexConfiguration;
+use JeroenG\Explorer\Domain\IndexManagement\IndexConfigurationRepositoryInterface;
+use JeroenG\Explorer\Infrastructure\IndexManagement\Job\UpdateIndexAlias;
+use JeroenG\Explorer\Tests\Support\Models\SyncableModel;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\Assert;
+
+final class UpdateIndexAliasTest extends MockeryTestCase
+{
+    public function testJobCreation(): void
+    {
+        $config = DirectIndexConfiguration::create(
+            name: ':index:',
+            properties: [],
+            settings: [],
+            model: SyncableModel::class,
+        );
+
+        $subject = UpdateIndexAlias::createFor($config);
+
+        Assert::assertSame(':queue:', $subject->queue);
+        Assert::assertSame(':connection:', $subject->connection);
+        Assert::assertSame(':index:', $subject->index);
+
+    }
+
+    public function testHandleCallsPointToIndex(): void
+    {
+        $adapter = Mockery::mock(IndexAdapterInterface::class);
+        $repository = Mockery::mock(IndexConfigurationRepositoryInterface::class);
+
+        $config = DirectIndexConfiguration::create(
+            name: ':index:',
+            properties: [],
+            settings: [],
+            model: SyncableModel::class,
+        );
+
+        $repository
+            ->expects('findForIndex')
+            ->with(':index:')
+            ->andReturn($config);
+
+        $adapter
+            ->expects('pointToAlias')
+            ->with($config);
+
+        UpdateIndexAlias::createFor($config)
+            ->handle($adapter, $repository);
+
+    }
+}


### PR DESCRIPTION
Hi,

Issue:
Alias substitution is happening too quickly (after sending all the documents to the queue), not all documents will be indexed in Elasticsearch.

Solution:
Delay the alias substitution by queuing the job. The substitution will occur when all or most of the documents have been indexed.