### PR TITLE
allow custom order by

### DIFF
--- a/src/Infrastructure/Scout/ScoutSearchCommandBuilder.php
+++ b/src/Infrastructure/Scout/ScoutSearchCommandBuilder.php
@@ -12,6 +12,7 @@ use JeroenG\Explorer\Domain\Syntax\Compound\BoolQuery;
 use JeroenG\Explorer\Domain\Syntax\Compound\QueryType;
 use JeroenG\Explorer\Domain\Syntax\MultiMatch;
 use JeroenG\Explorer\Domain\Syntax\Sort;
+use JeroenG\Explorer\Domain\Syntax\SyntaxInterface;
 use JeroenG\Explorer\Domain\Syntax\Term;
 use JeroenG\Explorer\Domain\Syntax\Terms;
 use Laravel\Scout\Builder;
@@ -33,7 +34,7 @@ class ScoutSearchCommandBuilder implements SearchCommandInterface
 
     private ?string $minimumShouldMatch = null;
 
-    /** @var Sort[]  */
+    /** @var SyntaxInterface[]  */
     private array $sort = [];
 
     private array $aggregations = [];
@@ -207,7 +208,7 @@ class ScoutSearchCommandBuilder implements SearchCommandInterface
 
     public function setSort(array $sort): void
     {
-        Assert::allIsInstanceOf($sort, Sort::class);
+        Assert::allIsInstanceOf($sort, SyntaxInterface::class);
         $this->sort = $sort;
     }
 
@@ -307,6 +308,8 @@ class ScoutSearchCommandBuilder implements SearchCommandInterface
     /** @return Sort[] */
     private static function getSorts(Builder $builder): array
     {
-        return array_map(static fn ($order) => new Sort($order['column'], $order['direction']), $builder->orders);
+        return array_map(static function($order) {
+            return $order instanceof SyntaxInterface ? $order : new Sort($order['column'], $order['direction']);
+        }, $builder->orders);
     }
 }

--- a/src/Infrastructure/Scout/ScoutSearchCommandBuilder.php
+++ b/src/Infrastructure/Scout/ScoutSearchCommandBuilder.php
@@ -305,7 +305,7 @@ class ScoutSearchCommandBuilder implements SearchCommandInterface
         return $this->offset;
     }
 
-    /** @return Sort[] */
+    /** @return SyntaxInterface[] */
     private static function getSorts(Builder $builder): array
     {
         return array_map(static function($order) {

--- a/tests/Unit/ScoutSearchCommandBuilderTest.php
+++ b/tests/Unit/ScoutSearchCommandBuilderTest.php
@@ -140,12 +140,12 @@ class ScoutSearchCommandBuilderTest extends TestCase
         $command->setSort([new Sort('id', 'invalid')]);
     }
 
-    public function test_it_only_accepts_sort_classes(): void
+    public function test_it_only_accepts_syntax_interface_classes(): void
     {
         $command = new ScoutSearchCommandBuilder();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected an instance of JeroenG\Explorer\Domain\Syntax\Sort. Got: string');
+        $this->expectExceptionMessage('Expected an instance of JeroenG\Explorer\Domain\Syntax\SyntaxInterface. Got: string');
 
         $command->setSort(['not' => 'a class']);
     }

--- a/tests/Unit/ScoutSearchCommandBuilderTest.php
+++ b/tests/Unit/ScoutSearchCommandBuilderTest.php
@@ -174,11 +174,11 @@ class ScoutSearchCommandBuilderTest extends TestCase
         $builder->model = Mockery::mock(Model::class);
 
         $builder->index = self::TEST_INDEX;
-        $builder->orders = [[ 'column' => 'id', 'direction' => 'asc']];
+        $builder->orders = [['column' => 'id', 'direction' => 'asc'], new Sort('name')];
 
         $subject = ScoutSearchCommandBuilder::wrap($builder);
 
-        self::assertSame([['id' => 'asc']], $subject->getSort());
+        self::assertSame([['id' => 'asc'], ['name' => 'asc']], $subject->getSort());
     }
 
     public function test_it_can_get_the_fields_from_scout_builder(): void


### PR DESCRIPTION
Some people might wanna use more complex order by statements like this:

"sort": [
    {
      "prices.value": {
        "order": "desc",
        "nested": {
          "path": "prices",
          "filter": {
            "term": {
              "prices.shop_id": "6f8c648c-112e-43ad-a93d-7ca72ea90aee"
            }
          }
        }
      }
    }
  ] 
  
So I think it wise to allow adding SyntaxInterface objects to the ScoutSearchCommandBuilder's $sort array, and not just Sort objects.

Thanks
