### PR TITLE
Allowing Dates in Range

### DIFF
--- a/src/Domain/Syntax/Range.php
+++ b/src/Domain/Syntax/Range.php
@@ -36,7 +36,10 @@ class Range implements SyntaxInterface
         foreach ($definitions as $key => $value) {
             Assert::inArray($key, self::RELATIONS);
             Assert::notNull($value);
-            Assert::numeric($value);
+			
+            if (strtotime($value) === false) {
+                Assert::numeric($value);
+            }
         }
     }
 }


### PR DESCRIPTION
This allows a Date to be compared by range without the need to convert it to Unix timestamp (Numeric value).