### PR TITLE
Allowing Dates in Range & new Around() Syntax

### DIFF
--- a/src/Domain/Syntax/Around.php
+++ b/src/Domain/Syntax/Around.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Explorer\Domain\Syntax;
+
+use Webmozart\Assert\Assert;
+
+class Around implements SyntaxInterface {
+	private string $field;
+
+	private mixed $value;
+
+	private float $tolerance;
+
+	private bool $percentage;
+
+	private bool $date;
+
+	private ?float $boost;
+
+	public function __construct(string $field, $value, float $tolerance = 5, ?bool $percentage = false, ?bool $date = false, ?float $boost = 1.0) {
+		$this->field = $field;
+		$this->value = $value;
+		$this->tolerance = $tolerance;
+		$this->percentage = $percentage;
+		$this->date = $date;
+		$this->boost = $boost;
+	}
+
+	public function build(): array {
+		if ($this->date) {
+			$days = (int) $this->tolerance;
+			$lte = date('Y-m-d H:i:s', strtotime("+{$days} day", strtotime($this->value)));
+			$gte = date('Y-m-d H:i:s', strtotime("-{$days} day", strtotime($this->value)));
+		} else {
+			$modifier = $this->percentage ? $this->value * $this->tolerance : $this->tolerance;
+			$lte = $this->value + $modifier;
+			$gte = $this->value - $modifier;
+		}
+
+		return ['range' => [
+			$this->field => ['lte' => $lte, 'gte' => $gte, 'boost' => $this->boost],
+		]];
+	}
+}

--- a/src/Domain/Syntax/Range.php
+++ b/src/Domain/Syntax/Range.php
@@ -16,11 +16,14 @@ class Range implements SyntaxInterface
 
     private ?float $boost;
 
-    public function __construct(string $field, array $definitions, ?float $boost = 1.0)
+    private ?bool $date;
+
+    public function __construct(string $field, array $definitions, ?float $boost = 1.0, ?bool $date = false)
     {
         $this->field = $field;
         $this->definitions = $definitions;
         $this->boost = $boost;
+        $this->date = $date;
         $this->validateDefinitions($definitions);
     }
 
@@ -36,7 +39,10 @@ class Range implements SyntaxInterface
         foreach ($definitions as $key => $value) {
             Assert::inArray($key, self::RELATIONS);
             Assert::notNull($value);
-            Assert::numeric($value);
+            
+            if (!$this->date) {
+                Assert::numeric($value);
+            }
         }
     }
 }


### PR DESCRIPTION
This allows a Date to be compared by range without the need to convert it to Unix timestamp (Numeric value).
Implementing new Syntax Around() which is range with a tolerance factor.