### PR TITLE
Add support for getting aggregations on nested aggregation results

### DIFF
--- a/src/Application/Results.php
+++ b/src/Application/Results.php
@@ -30,6 +30,15 @@ class Results implements Countable
         $aggregations = [];
 
         foreach ($this->rawResults['aggregations'] as $name => $rawAggregation) {
+            if (array_key_exists('doc_count', $rawAggregation)) {
+                foreach ($rawAggregation as $nestedAggregationName => $rawNestedAggregation) {
+                    if (isset($rawNestedAggregation['buckets'])) {
+                        $aggregations[] = new AggregationResult($nestedAggregationName, $rawNestedAggregation['buckets']);
+                    }
+                }
+                continue;
+            }
+
             $aggregations[] = new AggregationResult($name, $rawAggregation['buckets']);
         }
 

--- a/tests/Unit/FinderTest.php
+++ b/tests/Unit/FinderTest.php
@@ -433,11 +433,9 @@ class FinderTest extends MockeryTestCase
 
         $nestedAggregationValue = $nestedAggregation->values()[0];
 
-
         self::assertEquals(6, $nestedAggregationValue['doc_count']);
         self::assertEquals('someKey', $nestedAggregationValue['key']);
     }
-
 
     private function hit(int $id = 1, float $score = 1.0): array
     {

--- a/tests/Unit/FinderTest.php
+++ b/tests/Unit/FinderTest.php
@@ -391,6 +391,7 @@ class FinderTest extends MockeryTestCase
                                 ],
                             ],
                         ],
+                        'anotherAggregation' => ['terms' => ['field' => 'anotherField', 'size' => 10]]
                     ],
                 ],
             ])
@@ -410,10 +411,16 @@ class FinderTest extends MockeryTestCase
                             ],
                         ],
                     ],
+                    'specificAggregation' => [
+                        'buckets' => [
+                            ['key' => 'myKey', 'doc_count' => 42]
+                        ]
+                    ],
                 ],
             ]);
 
         $query = Query::with(new BoolQuery());
+        $query->addAggregation('anotherAggregation', new TermsAggregation('anotherField'));
         $nestedAggregation = new NestedAggregation('nestedAggregation');
         $nestedAggregation->add('someField', new TermsAggregation('nestedAggregation.someField'));
         $query->addAggregation('nestedAggregation',$nestedAggregation);
@@ -423,7 +430,7 @@ class FinderTest extends MockeryTestCase
         $subject = new Finder($client, $builder);
         $results = $subject->find();
 
-        self::assertCount(1, $results->aggregations());
+        self::assertCount(2, $results->aggregations());
 
         $nestedAggregation = $results->aggregations()[0];
 


### PR DESCRIPTION
The `aggregations()` method on a `Results` class fails if the result contains a nested aggregation, in which case there is no key `buckets` available. 
The nested aggregation can be recognized by the presence of the `doc_count` key, which is absent otherwise. 

