### PR TITLE
Fixes non-bucket based aggregations throwing exception

### DIFF
--- a/src/Application/AggregationResult.php
+++ b/src/Application/AggregationResult.php
@@ -6,7 +6,7 @@ namespace JeroenG\Explorer\Application;
 
 class AggregationResult
 {
-    public function __construct(private string $name, private array $buckets)
+    public function __construct(private string $name, private array $values)
     {
     }
 
@@ -17,6 +17,6 @@ class AggregationResult
 
     public function values(): array
     {
-        return $this->buckets;
+        return $this->values;
     }
 }

--- a/src/Application/Results.php
+++ b/src/Application/Results.php
@@ -32,7 +32,9 @@ class Results implements Countable
         foreach ($this->rawResults['aggregations'] as $name => $rawAggregation) {
             if (array_key_exists('doc_count', $rawAggregation)) {
                 foreach ($rawAggregation as $nestedAggregationName => $rawNestedAggregation) {
-                    $aggregations[] = new AggregationResult($nestedAggregationName, $rawNestedAggregation['buckets'] ?? $rawNestedAggregation);
+                    if (isset($rawNestedAggregation['buckets'])) {
+                        $aggregations[] = new AggregationResult($nestedAggregationName, $rawNestedAggregation['buckets']);
+                    }
                 }
                 continue;
             }

--- a/src/Application/Results.php
+++ b/src/Application/Results.php
@@ -32,14 +32,12 @@ class Results implements Countable
         foreach ($this->rawResults['aggregations'] as $name => $rawAggregation) {
             if (array_key_exists('doc_count', $rawAggregation)) {
                 foreach ($rawAggregation as $nestedAggregationName => $rawNestedAggregation) {
-                    if (isset($rawNestedAggregation['buckets'])) {
-                        $aggregations[] = new AggregationResult($nestedAggregationName, $rawNestedAggregation['buckets']);
-                    }
+                    $aggregations[] = new AggregationResult($nestedAggregationName, $rawNestedAggregation['buckets'] ?? $rawNestedAggregation);
                 }
                 continue;
             }
 
-            $aggregations[] = new AggregationResult($name, $rawAggregation['buckets']);
+            $aggregations[] = new AggregationResult($name, $rawAggregation['buckets'] ?? $rawAggregation);
         }
 
         return $aggregations;


### PR DESCRIPTION
Currently using the `MaxAggregation` throws an exception because the `buckets` key cannot be found, which is correct because [according to the docs](https://www.elastic.co/guide/en/elasticsearch/reference/8.10/search-aggregations-metrics-max-aggregation.html) the max aggregation doesn't have a `buckets` key.
The 
# The fix:
When the above scenario happens it will dump the raw aggregation data as the  `AggregationResult->values`.

# Notes
I'm aware it isn't the cleanest of implementations, but this way it ensures backwards compatibility.