### PR TITLE
Search cross multiple index

### DIFF
--- a/src/Application/Model/MixedSearch.php
+++ b/src/Application/Model/MixedSearch.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Explorer\Application\Model;
+
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Scout\Builder;
+use Laravel\Scout\Searchable;
+
+class MixedSearch
+{
+    /**
+     * Perform a search against the model's indexed data.
+     *
+     * @param string $query
+     * @param \Closure $callback
+     * @return \Laravel\Scout\Builder
+     */
+    public static function search($query = '', $callback = null)
+    {
+        return app(Builder::class, [
+            'model' => new class extends Model {
+                use Searchable;
+            },
+            'query' => $query,
+            'callback' => $callback
+        ]);
+    }
+}


### PR DESCRIPTION
I see in old [PR](https://github.com/Jeroen-G/Explorer/pull/80) and found code. rewrite it to current state for use `within()` Scout function as example
```
MixedSearch::search()->within(implode(',', [
    (new Movie())->searchableAs(),
    (new Series())->searchableAs(),
    (new Trailer())->searchableAs(),
]))->get();
```