### PR TITLE
Added option to use QueryString on some fields

### DIFF
--- a/src/Domain/Syntax/QueryString.php
+++ b/src/Domain/Syntax/QueryString.php
@@ -19,10 +19,13 @@ class QueryString implements SyntaxInterface
 
     protected string $defaultOperator;
 
-    public function __construct(string $queryString, string $defaultOperator = self::OP_OR, float $boost = 1.0)
+    protected array $fields;
+
+    public function __construct(string $queryString, string $defaultOperator = self::OP_OR, float $boost = 1.0, array $fields = [])
     {
         Assert::oneOf($defaultOperator, [self::OP_OR, self::OP_AND]);
 
+        $this->fields = $fields;
         $this->queryString = $queryString;
         $this->boost = $boost;
         $this->defaultOperator = $defaultOperator;
@@ -35,6 +38,7 @@ class QueryString implements SyntaxInterface
                 'query' => $this->queryString,
                 'default_operator' => $this->defaultOperator,
                 'boost' => $this->boost,
+                'fields' => $this->fields,
             ],
         ];
     }

--- a/src/Domain/Syntax/QueryString.php
+++ b/src/Domain/Syntax/QueryString.php
@@ -25,10 +25,10 @@ class QueryString implements SyntaxInterface
     {
         Assert::oneOf($defaultOperator, [self::OP_OR, self::OP_AND]);
 
-        $this->fields = $fields;
         $this->queryString = $queryString;
         $this->boost = $boost;
         $this->defaultOperator = $defaultOperator;
+        $this->fields = $fields;
     }
 
     public function build(): array

--- a/tests/Unit/Syntax/QueryStringTest.php
+++ b/tests/Unit/Syntax/QueryStringTest.php
@@ -19,6 +19,7 @@ class QueryStringTest extends TestCase
                 'query' => 'test',
                 'default_operator' => 'OR',
                 'boost' => 1.0,
+                'fields' => [],
             ]
         ];
 
@@ -36,6 +37,25 @@ class QueryStringTest extends TestCase
                 'query' => 'test',
                 'default_operator' => 'AND',
                 'boost' => 1.0,
+                'fields' => [],
+            ]
+        ];
+
+        $query = $subject->build();
+
+        self::assertSame($expected, $query);
+    }
+
+    public function test_it_can_accept_fields(): void
+    {
+        $subject = new QueryString('test', QueryString::OP_AND, 1.0, ['field1', 'field2']);
+
+        $expected = [
+            'query_string' => [
+                'query' => 'test',
+                'default_operator' => 'AND',
+                'boost' => 1.0,
+                'fields' => ['field1', 'field2'],
             ]
         ];
 


### PR DESCRIPTION
For some project we've needed to QueryString search on some specific fields.
This changes should be non-breaking, so I think there is no major release needed.

If you needed more information, feel free to reach out on Slack @Jeroen-G  