### PR TITLE
Add elastic8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2, 8.3]
+        php: [8.2, 8.3, 8.4]
         experimental: [ false ]
         include:
           - php: 8.4

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.1, 8.2, 8.3]
+        php: [8.2, 8.3, 8.4]
 
     name: Mutation Testing Code Review Annotations ${{ matrix.php }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 /node_modules
 /report
 .phpunit.result.cache
+.phpunit.cache
 composer.lock
 infection.log

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ElasticSearch 7 support: the elastic 8 client is not backwards compatible. See 'changed' for the breaking changes.
 - Support for Laravel 9 and below to make package maintenance easier.
+- Support for PHP 8.0 and 8.1, as required by Laravel.
 
 ### Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+
+## Unreleased
+
+## [4.0.0]
+
+### Added
+
+- Support for elastic 8
+
+### Removed
+
+- Elastic 7 support. The elastic 8 client is not backwards compatible
+
+### Changed
+
+- The import path for `selector` has changed  from `Elasticsearch\ConnectionPool\Selectors\RoundRobinSelector` to `Elastic\Transport\NodePool\Selector\RoundRobin`
+
 ## [3.14.0]
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -12,17 +12,17 @@
     "homepage": "https://jeroen-g.github.io/Explorer/",
     "keywords": ["Laravel", "Scout", "Elasticsearch", "Elastic", "search", "Explorer"],
     "require": {
-        "php": "^8.0",
+        "php": "^8.2",
         "elasticsearch/elasticsearch": "^8.0",
-        "illuminate/support": "^9.0||^10.0||^11.0",
-        "laravel/scout": "^9.0||^10.0||^11.0",
+        "illuminate/support": "^11.0",
+        "laravel/scout": "^10.0",
         "webmozart/assert": "^1.10",
-        "psr/log": "^1|^2|^3"
+        "psr/log": "^3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~9.0",
+        "phpunit/phpunit": "^10.0",
         "mockery/mockery": "^1.5",
-        "infection/infection": "^0.26",
+        "infection/infection": "^0.29",
         "symplify/easy-coding-standard": "^9.0",
         "nunomaduro/larastan": "^2.5",
         "phpstan/phpstan-mockery": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     "homepage": "https://jeroen-g.github.io/Explorer/",
     "keywords": ["Laravel", "Scout", "Elasticsearch", "Elastic", "search", "Explorer"],
     "require": {
-        "php": "8.0.*||8.1.*||8.2.*||8.3.*",
-        "elasticsearch/elasticsearch": "^7.16",
+        "php": "^8.0",
+        "elasticsearch/elasticsearch": "^8.0",
         "illuminate/support": "^9.0||^10.0||^11.0",
         "laravel/scout": "^9.0||^10.0||^11.0",
         "webmozart/assert": "^1.10",
@@ -26,7 +26,8 @@
         "symplify/easy-coding-standard": "^9.0",
         "nunomaduro/larastan": "^2.5",
         "phpstan/phpstan-mockery": "^1.1",
-        "orchestra/testbench": "*"
+        "orchestra/testbench": "*",
+        "dg/bypass-finals": "^1.8"
     },
     "autoload": {
         "psr-4": {

--- a/docs/connection.md
+++ b/docs/connection.md
@@ -117,7 +117,7 @@ To disable TLS verification set it to `false`. **NOT recommended for production*
 Elastic can also have multiple possible connections
 
 ```php
-    use Elasticsearch\ConnectionPool\Selectors\RoundRobinSelector;
+    use Elastic\Transport\NodePool\Selector\RoundRobin;
     
     return [
         'connection' => [
@@ -127,7 +127,7 @@ Elastic can also have multiple possible connections
             'ssl' => [
                 'verify' => false,
             ],
-            'selector' => RoundRobinSelector::class
+            'selector' => RoundRobin::class
         ],
         'additionalConnections' => [
             [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12,10 +12,5 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method JeroenG\\\\Explorer\\\\Domain\\\\IndexManagement\\\\IndexConfigurationInterface\\:\\:getAliasConfiguration\\(\\)\\.$#"
-			count: 1
-			path: src/Infrastructure/Elastic/ElasticIndexAdapter.php
-
-		-
-			message: "#^Call to an undefined method JeroenG\\\\Explorer\\\\Domain\\\\IndexManagement\\\\IndexConfigurationInterface\\:\\:getAliasConfiguration\\(\\)\\.$#"
 			count: 2
 			path: tests/Unit/IndexManagement/ElasticIndexConfigurationRepositoryTest.php

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory>src/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
     <testsuite name="unit">
       <directory suffix=".php">./tests/Unit</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory>src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage>
     <include>
       <directory>src/</directory>

--- a/src/Application/IndexAdapterInterface.php
+++ b/src/Application/IndexAdapterInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JeroenG\Explorer\Application;
 
+use JeroenG\Explorer\Domain\IndexManagement\AliasedIndexConfigurationInterface;
 use JeroenG\Explorer\Domain\IndexManagement\IndexConfigurationInterface;
 
 interface IndexAdapterInterface
@@ -16,7 +17,7 @@ interface IndexAdapterInterface
 
     public function flush(string $index): void;
 
-    public function createNewWriteIndex(IndexConfigurationInterface $indexConfiguration): string;
+    public function createNewWriteIndex(AliasedIndexConfigurationInterface $indexConfiguration): string;
 
     public function ensureIndex(IndexConfigurationInterface $indexConfiguration): void;
 }

--- a/src/Domain/IndexManagement/AliasedIndexConfiguration.php
+++ b/src/Domain/IndexManagement/AliasedIndexConfiguration.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace JeroenG\Explorer\Domain\IndexManagement;
 
-final class AliasedIndexConfiguration implements  IndexConfigurationInterface
+final class AliasedIndexConfiguration implements AliasedIndexConfigurationInterface
 {
     private function __construct(
         private string $name,

--- a/src/Domain/IndexManagement/AliasedIndexConfigurationInterface.php
+++ b/src/Domain/IndexManagement/AliasedIndexConfigurationInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Explorer\Domain\IndexManagement;
+
+interface AliasedIndexConfigurationInterface extends IndexConfigurationInterface
+{
+    public function getAliasConfiguration(): IndexAliasConfigurationInterface;
+}

--- a/src/Domain/Syntax/RegExp.php
+++ b/src/Domain/Syntax/RegExp.php
@@ -7,14 +7,14 @@ namespace JeroenG\Explorer\Domain\Syntax;
 class RegExp implements SyntaxInterface
 {
     private string $field;
-    
+
     private ?string $value;
 
     private string $flags;
 
     private bool $insensitive;
 
-    public function __construct(string $field, string $value = null, string $flags = 'ALL', bool $insensitive = false)
+    public function __construct(string $field, ?string $value = null, string $flags = 'ALL', bool $insensitive = false)
     {
         $this->field = $field;
         $this->value = $value;

--- a/src/ExplorerServiceProvider.php
+++ b/src/ExplorerServiceProvider.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace JeroenG\Explorer;
 
-use Elasticsearch\Client;
+use Elastic\Elasticsearch\Client;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use JeroenG\Explorer\Application\DocumentAdapterInterface;
 use JeroenG\Explorer\Application\IndexAdapterInterface;
-use JeroenG\Explorer\Domain\Aggregations\AggregationSyntaxInterface;
 use JeroenG\Explorer\Domain\IndexManagement\IndexConfigurationRepositoryInterface;
 use JeroenG\Explorer\Infrastructure\Console\ElasticSearch;
 use JeroenG\Explorer\Infrastructure\Console\ElasticUpdate;
@@ -17,7 +16,6 @@ use JeroenG\Explorer\Infrastructure\Elastic\ElasticClientFactory;
 use JeroenG\Explorer\Infrastructure\Elastic\ElasticClientBuilder;
 use JeroenG\Explorer\Infrastructure\Elastic\ElasticDocumentAdapter;
 use JeroenG\Explorer\Infrastructure\Elastic\ElasticIndexAdapter;
-use JeroenG\Explorer\Infrastructure\IndexManagement\ElasticIndexChangedChecker;
 use JeroenG\Explorer\Infrastructure\IndexManagement\ElasticIndexConfigurationRepository;
 use JeroenG\Explorer\Infrastructure\Scout\Builder;
 use JeroenG\Explorer\Infrastructure\Scout\ElasticEngine;

--- a/src/Infrastructure/Elastic/ElasticClientBuilder.php
+++ b/src/Infrastructure/Elastic/ElasticClientBuilder.php
@@ -27,7 +27,14 @@ final class ElasticClientBuilder
         );
 
         if (!empty($hostConnectionProperties)) {
-            $builder->setHosts([$hostConnectionProperties]);
+            $builder->setHosts([
+                sprintf(
+                    "%s://%s:%s",
+                    $hostConnectionProperties['scheme'],
+                    $hostConnectionProperties['host'],
+                    $hostConnectionProperties['port']
+                ),
+            ]);
         }
 
         if ($config->has('explorer.additionalConnections')) {

--- a/src/Infrastructure/Elastic/ElasticClientFactory.php
+++ b/src/Infrastructure/Elastic/ElasticClientFactory.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace JeroenG\Explorer\Infrastructure\Elastic;
 
-use Elasticsearch\Client;
-use Elasticsearch\ClientBuilder;
-use GuzzleHttp\Ring\Client\MockHandler;
+use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientBuilder;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
 
 final class ElasticClientFactory
 {
@@ -24,10 +25,11 @@ final class ElasticClientFactory
 
     public static function fake(FakeResponse $response): ElasticClientFactory
     {
-        $handler = new MockHandler($response->toArray());
+        $handler = new MockHandler([$response->toResponse()]);
+
         $builder = ClientBuilder::create();
         $builder->setHosts(['testhost']);
-        $builder->setHandler($handler);
+        $builder->setHttpClient(new GuzzleClient(['handler' => $handler]));
         return new self($builder->build());
     }
 }

--- a/src/Infrastructure/Elastic/FakeResponse.php
+++ b/src/Infrastructure/Elastic/FakeResponse.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace JeroenG\Explorer\Infrastructure\Elastic;
 
+use Elastic\Elasticsearch\Response\Elasticsearch;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
 use Webmozart\Assert\Assert;
 
 class FakeResponse
@@ -30,5 +33,17 @@ class FakeResponse
             'body' => $this->body,
             'effective_url' => 'localhost'
         ];
+    }
+
+    public function toResponse(): ResponseInterface
+    {
+        return new Response(
+            $this->statusCode,
+            [
+                Elasticsearch::HEADER_CHECK => Elasticsearch::PRODUCT_NAME,
+                'Content-Type' => 'application/json',
+            ],
+            $this->body
+        );
     }
 }

--- a/src/Infrastructure/Elastic/Finder.php
+++ b/src/Infrastructure/Elastic/Finder.php
@@ -4,14 +4,18 @@ declare(strict_types=1);
 
 namespace JeroenG\Explorer\Infrastructure\Elastic;
 
-use Elasticsearch\Client;
+use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientInterface;
 use JeroenG\Explorer\Application\Results;
 use JeroenG\Explorer\Application\SearchCommandInterface;
 
 class Finder
 {
+    /**
+     * @param Client $client
+     */
     public function __construct(
-        private Client $client,
+        private ClientInterface $client,
         private SearchCommandInterface $builder,
     ) {
     }
@@ -23,7 +27,7 @@ class Finder
             'body' => $this->builder->buildQuery(),
         ];
 
-        $rawResults = $this->client->search($query);
+        $rawResults = $this->client->search($query)->asArray();
 
         return new Results($rawResults);
     }

--- a/tests/Support/ClientExpectation.php
+++ b/tests/Support/ClientExpectation.php
@@ -1,10 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace JeroenG\Explorer\Tests\Unit;
+namespace JeroenG\Explorer\Tests\Support;
 
 use Elastic\Elasticsearch\Client;
-use Elastic\Elasticsearch\ClientInterface;
 use Mockery;
 use Mockery\MockInterface;
 

--- a/tests/Support/FakeElasticResponse.php
+++ b/tests/Support/FakeElasticResponse.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace JeroenG\Explorer\Tests\Unit;
+namespace JeroenG\Explorer\Tests\Support;
 
 use Elastic\Elasticsearch\Response\Elasticsearch;
 use GuzzleHttp\Psr7\Response;

--- a/tests/Support/QueryTypeProvider.php
+++ b/tests/Support/QueryTypeProvider.php
@@ -8,13 +8,13 @@ use JeroenG\Explorer\Domain\Syntax\Compound\QueryType;
 
 trait QueryTypeProvider
 {
-    public function getQueryTypes(): array
+    public static function getQueryTypes(): array
     {
         return QueryType::ALL;
     }
 
-    public function queryTypeProvider(): array
+    public static function queryTypeProvider(): array
     {
-        return array_map(fn ($item) => [$item], $this->getQueryTypes());
+        return array_map(fn ($item) => [$item], self::getQueryTypes());
     }
 }

--- a/tests/Support/SyntaxProvider.php
+++ b/tests/Support/SyntaxProvider.php
@@ -10,12 +10,12 @@ use JeroenG\Explorer\Domain\Syntax\Term;
 
 trait SyntaxProvider
 {
-    public function syntaxProvider(): array
+    public static function syntaxProvider(): array
     {
-        return array_map(fn ($item) => [$item], $this->getSyntaxClasses());
+        return array_map(fn ($item) => [$item], self::getSyntaxClasses());
     }
 
-    public function getSyntaxClasses(): array
+    public static function getSyntaxClasses(): array
     {
         return [
             Matching::class,

--- a/tests/Unit/ClientExpectation.php
+++ b/tests/Unit/ClientExpectation.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace JeroenG\Explorer\Tests\Unit;
+
+use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientInterface;
+use Mockery;
+use Mockery\MockInterface;
+
+final class ClientExpectation
+{
+    private MockInterface|Client $mock;
+
+    public function __construct(MockInterface|Client $mock)
+    {
+        $this->mock = $mock;
+    }
+
+    public static function create(): self
+    {
+
+        return new self(Mockery::mock(Client::class));
+    }
+
+    public function getMock(): Client
+    {
+        return $this->mock;
+    }
+
+    public function expectSearch(array $input, FakeElasticResponse $response): void
+    {
+        $this->mock
+            ->expects('search')
+            ->with($input)
+            ->andReturn($response);
+    }
+}

--- a/tests/Unit/Domain/Query/QueryProperties/SourceFilterTest.php
+++ b/tests/Unit/Domain/Query/QueryProperties/SourceFilterTest.php
@@ -21,7 +21,7 @@ final class SourceFilterTest extends TestCase
         Assert::assertSame([], SourceFilter::empty()->build());
     }
 
-    public function provideSourceFilterValues(): iterable
+    public static function provideSourceFilterValues(): iterable
     {
         yield 'include 2 fields' => [
             [ 'include' => ['a', 'b'] ],

--- a/tests/Unit/Domain/Query/QueryProperties/TrackTotalHitsTest.php
+++ b/tests/Unit/Domain/Query/QueryProperties/TrackTotalHitsTest.php
@@ -26,7 +26,7 @@ final class TrackTotalHitsTest extends TestCase
         Assert::assertSame([ 'track_total_hits' => false ], TrackTotalHits::none()->build());
     }
 
-    public function provideTrackTotalHitCounts(): iterable
+    public static function provideTrackTotalHitCounts(): iterable
     {
         yield 'count 100' => [100];
         yield 'count -100' => [-100];

--- a/tests/Unit/Domain/Syntax/SortOrderTest.php
+++ b/tests/Unit/Domain/Syntax/SortOrderTest.php
@@ -7,17 +7,17 @@ use JeroenG\Explorer\Domain\Syntax\SortOrder;
 use PHPUnit\Framework\TestCase;
 
 final class SortOrderTest extends TestCase
-{    
+{
     public function test_it_uses_default_missing_when_creating_sort_order(): void
     {
         $sort = SortOrder::for(SortOrder::DESCENDING);
-        
+
         Assert::assertSame([
             'missing' => SortOrder::MISSING_LAST,
             'order' => SortOrder::DESCENDING
         ], $sort->build());
     }
-    
+
     /**
      * @dataProvider provideSortOrderStrings
      */
@@ -26,7 +26,7 @@ final class SortOrderTest extends TestCase
         $subject = SortOrder::fromString($sortString);
         Assert::assertSame($expectedResult, $subject->build());
     }
-    
+
     /**
      * @dataProvider provideMissingSortOrderStrings
      */
@@ -35,18 +35,18 @@ final class SortOrderTest extends TestCase
         $subject = SortOrder::for($sortString, $missing);
         Assert::assertSame($expectedResult, $subject->build());
     }
-    
-    public function provideSortOrderStrings(): iterable
+
+    public static function provideSortOrderStrings(): iterable
     {
         yield 'asc' => ['asc', 'asc'];
         yield 'desc' => ['desc', 'desc'];
     }
-    
-    public function provideMissingSortOrderStrings(): iterable
+
+    public static function provideMissingSortOrderStrings(): iterable
     {
         yield 'asc order with _last missing' => [['missing' => '_last', 'order' => 'asc'], 'asc', '_last'];
         yield 'desc order with _last missing' => [['missing' => '_last', 'order' => 'desc'], 'desc', '_last'];
         yield 'asc order with _first missing' => [['missing' => '_first', 'order' => 'asc'], 'asc', '_first'];
         yield 'desc order with _first missing' => [['missing' => '_first', 'order' => 'desc'], 'desc', '_first'];
-    }    
+    }
 }

--- a/tests/Unit/ElasticClientBuilderTest.php
+++ b/tests/Unit/ElasticClientBuilderTest.php
@@ -34,7 +34,7 @@ final class ElasticClientBuilderTest extends MockeryTestCase
         self::assertEquals($expectedBuilder, $resultBuilder);
     }
 
-    public function provideClientConfigs(): ?\Generator
+    public static function provideClientConfigs(): ?\Generator
     {
         yield 'simple host' => [
             [

--- a/tests/Unit/ElasticClientBuilderTest.php
+++ b/tests/Unit/ElasticClientBuilderTest.php
@@ -19,6 +19,7 @@ final class ElasticClientBuilderTest extends MockeryTestCase
     private const CLOUD_ID = 'staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw';
 
     private const CONNECTION = [ 'host' => 'example.com', 'port' => '9222', 'scheme' => 'https' ];
+
     private const CONNECTION_STRING = 'https://example.com:9222';
 
     /** @dataProvider provideClientConfigs */

--- a/tests/Unit/ElasticClientBuilderTest.php
+++ b/tests/Unit/ElasticClientBuilderTest.php
@@ -19,6 +19,7 @@ final class ElasticClientBuilderTest extends MockeryTestCase
     private const CLOUD_ID = 'staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw';
 
     private const CONNECTION = [ 'host' => 'example.com', 'port' => '9222', 'scheme' => 'https' ];
+    private const CONNECTION_STRING = 'https://example.com:9222';
 
     /** @dataProvider provideClientConfigs */
     public function test_it_creates_client_with_config(array $config, ClientBuilder $expectedBuilder): void
@@ -39,7 +40,7 @@ final class ElasticClientBuilderTest extends MockeryTestCase
                 'connection' => self::CONNECTION
             ],
             ClientBuilder::create()
-                ->setHosts([self::CONNECTION])
+                ->setHosts([self::CONNECTION_STRING])
         ];
 
          yield 'elastic cloud id' => [
@@ -62,7 +63,7 @@ final class ElasticClientBuilderTest extends MockeryTestCase
                 ], self::CONNECTION)
             ],
             ClientBuilder::create()
-                ->setHosts([self::CONNECTION])
+                ->setHosts([self::CONNECTION_STRING])
                 ->setBasicAuthentication('myName', 'myPassword'),
         ];
 
@@ -76,7 +77,7 @@ final class ElasticClientBuilderTest extends MockeryTestCase
                 ], self::CONNECTION)
             ],
             ClientBuilder::create()
-                ->setHosts([self::CONNECTION])
+                ->setHosts([self::CONNECTION_STRING])
                 ->setApiKey('myId', 'myKey'),
         ];
 
@@ -87,7 +88,7 @@ final class ElasticClientBuilderTest extends MockeryTestCase
                 ], self::CONNECTION)
             ],
             ClientBuilder::create()
-                ->setHosts([self::CONNECTION])
+                ->setHosts([self::CONNECTION_STRING])
                 ->setNodePool(new SimpleNodePool(new RoundRobin(), new ElasticsearchResurrect())),
         ];
 
@@ -110,7 +111,7 @@ final class ElasticClientBuilderTest extends MockeryTestCase
                 ], self::CONNECTION)
             ],
             ClientBuilder::create()
-                ->setHosts([self::CONNECTION])
+                ->setHosts([self::CONNECTION_STRING])
                 ->setSSLVerification(false),
         ];
 
@@ -121,7 +122,7 @@ final class ElasticClientBuilderTest extends MockeryTestCase
                 ], self::CONNECTION)
             ],
             ClientBuilder::create()
-                ->setHosts([self::CONNECTION])
+                ->setHosts([self::CONNECTION_STRING])
                 ->setSSLVerification(),
         ];
 
@@ -135,7 +136,7 @@ final class ElasticClientBuilderTest extends MockeryTestCase
                 ], self::CONNECTION)
             ],
             ClientBuilder::create()
-                ->setHosts([self::CONNECTION])
+                ->setHosts([self::CONNECTION_STRING])
                 ->setSSLCert('path/to/cert.pem', 'passphrase')
                 ->setSSLKey('path/to/key.pem', 'passphrase'),
         ];
@@ -150,7 +151,7 @@ final class ElasticClientBuilderTest extends MockeryTestCase
                 ], self::CONNECTION)
             ],
             ClientBuilder::create()
-                ->setHosts([self::CONNECTION])
+                ->setHosts([self::CONNECTION_STRING])
                 ->setSSLCert('path/to/cert.pem')
                 ->setSSLKey('path/to/key.pem'),
         ];
@@ -162,7 +163,7 @@ final class ElasticClientBuilderTest extends MockeryTestCase
                 'connection' => self::CONNECTION,
             ],
             ClientBuilder::create()
-                ->setHosts([self::CONNECTION])
+                ->setHosts([self::CONNECTION_STRING])
                 ->setLogger(new NullLogger()),
         ];
 
@@ -173,7 +174,7 @@ final class ElasticClientBuilderTest extends MockeryTestCase
                 'connection' => self::CONNECTION,
             ],
             ClientBuilder::create()
-                ->setHosts([self::CONNECTION]),
+                ->setHosts([self::CONNECTION_STRING]),
         ];
 
         yield 'without logger' => [
@@ -182,7 +183,7 @@ final class ElasticClientBuilderTest extends MockeryTestCase
                 'connection' => self::CONNECTION,
             ],
             ClientBuilder::create()
-                ->setHosts([self::CONNECTION]),
+                ->setHosts([self::CONNECTION_STRING]),
         ];
     }
 

--- a/tests/Unit/ElasticClientFactoryTest.php
+++ b/tests/Unit/ElasticClientFactoryTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace JeroenG\Explorer\Tests\Unit;
 
-use Elastic\Elasticsearch\ClientInterface;
 use JeroenG\Explorer\Application\SearchCommand;
 use JeroenG\Explorer\Domain\Query\Query;
 use JeroenG\Explorer\Domain\Syntax\Compound\BoolQuery;
 use JeroenG\Explorer\Infrastructure\Elastic\ElasticClientFactory;
 use JeroenG\Explorer\Infrastructure\Elastic\FakeResponse;
 use JeroenG\Explorer\Infrastructure\Elastic\Finder;
+use JeroenG\Explorer\Tests\Support\ClientExpectation;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 

--- a/tests/Unit/ElasticClientFactoryTest.php
+++ b/tests/Unit/ElasticClientFactoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace JeroenG\Explorer\Tests\Unit;
 
-use Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientInterface;
 use JeroenG\Explorer\Application\SearchCommand;
 use JeroenG\Explorer\Domain\Query\Query;
 use JeroenG\Explorer\Domain\Syntax\Compound\BoolQuery;
@@ -18,20 +18,11 @@ class ElasticClientFactoryTest extends MockeryTestCase
 {
     public function test_it_can_construct_a_client(): void
     {
-        $client = Mockery::mock(Client::class);
-        $factory = new ElasticClientFactory($client);
+        $client = ClientExpectation::create();
+        $factory = new ElasticClientFactory($client->getMock());
 
         self::assertInstanceOf(Mockery\MockInterface::class, $factory->client());
-        self::assertEquals($client, $factory->client());
-    }
-
-    public function test_it_can_create_a_real_client_with_fake_response(): void
-    {
-        $file = fopen(__DIR__.'/../Support/fakeresponse.json', 'rb');
-        $factory = ElasticClientFactory::fake(new FakeResponse(200, $file));
-
-        self::assertEquals('testhost', $factory->client()->transport->getConnection()->getHost());
-        self::assertNotInstanceOf(Mockery\MockInterface::class, $factory->client());
+        self::assertEquals($client->getMock(), $factory->client());
     }
 
     public function test_it_can_make_a_faked_call(): void

--- a/tests/Unit/FakeElasticResponse.php
+++ b/tests/Unit/FakeElasticResponse.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace JeroenG\Explorer\Tests\Unit;
+
+use Elastic\Elasticsearch\Response\Elasticsearch;
+use GuzzleHttp\Psr7\Response;
+
+final class FakeElasticResponse extends Elasticsearch
+{
+    public static function array(array $data): self
+    {
+        $self = new self();
+        $self->asArray = $data;
+        return $self;
+    }
+
+    public static function bool(bool $bool): self
+    {
+        $self = new self();
+        $self->response = new Response($bool ? 200 : 404);
+        return $self;
+    }
+}

--- a/tests/Unit/FinderTest.php
+++ b/tests/Unit/FinderTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use JeroenG\Explorer\Application\AggregationResult;
 use JeroenG\Explorer\Application\SearchCommand;
 use JeroenG\Explorer\Domain\Aggregations\MaxAggregation;
+use JeroenG\Explorer\Domain\Aggregations\NestedAggregation;
 use JeroenG\Explorer\Domain\Aggregations\NestedFilteredAggregation;
 use JeroenG\Explorer\Domain\Aggregations\TermsAggregation;
 use JeroenG\Explorer\Domain\Query\Query;
@@ -17,8 +18,9 @@ use JeroenG\Explorer\Domain\Syntax\Sort;
 use JeroenG\Explorer\Domain\Syntax\Term;
 use JeroenG\Explorer\Infrastructure\Elastic\Finder;
 use JeroenG\Explorer\Infrastructure\Scout\ScoutSearchCommandBuilder;
+use JeroenG\Explorer\Tests\Support\ClientExpectation;
+use JeroenG\Explorer\Tests\Support\FakeElasticResponse;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
-use JeroenG\Explorer\Domain\Aggregations\NestedAggregation;
 
 class FinderTest extends MockeryTestCase
 {

--- a/tests/Unit/IndexManagement/ElasticIndexConfigurationRepositoryTest.php
+++ b/tests/Unit/IndexManagement/ElasticIndexConfigurationRepositoryTest.php
@@ -13,6 +13,8 @@ use JeroenG\Explorer\Tests\Support\Models\TestModelWithAliased;
 use JeroenG\Explorer\Tests\Support\Models\TestModelWithoutSettings;
 use JeroenG\Explorer\Tests\Support\Models\TestModelWithSettings;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use RuntimeException;
+use StdClass;
 
 final class ElasticIndexConfigurationRepositoryTest extends MockeryTestCase
 {
@@ -105,14 +107,14 @@ final class ElasticIndexConfigurationRepositoryTest extends MockeryTestCase
 
     public function test_it_throws_on_invalid_model(): void
     {
-        $indices = [
-            self::class
-        ];
+        $indices = [get_class(new StdClass())];
 
         $repository = new ElasticIndexConfigurationRepository($indices);
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(sprintf('Unable to create index %s, ensure it implements Explored', self::class));
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            sprintf('Unable to create index %s, ensure it implements Explored', get_class(new StdClass()))
+        );
         iterator_to_array($repository->getConfigurations())[0] ?? null;
     }
 
@@ -121,12 +123,12 @@ final class ElasticIndexConfigurationRepositoryTest extends MockeryTestCase
     {
         $repository = new ElasticIndexConfigurationRepository($indices);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage($error);
         iterator_to_array($repository->getConfigurations());
     }
 
-    public function invalidIndices(): iterable
+    public static function invalidIndices(): iterable
     {
         yield [
             [false],

--- a/tests/Unit/IndexManagement/IndexAliasConfigurationTest.php
+++ b/tests/Unit/IndexManagement/IndexAliasConfigurationTest.php
@@ -34,7 +34,7 @@ final class IndexAliasConfigurationTest extends TestCase
         self::assertSame("shipIt-$alias", $config->$method());
     }
 
-    public function aliasProvider(): \Generator
+    public static function aliasProvider(): \Generator
     {
         yield ['history', 'getHistoryAliasName'];
         yield ['write', 'getWriteAliasName'];

--- a/tests/Unit/Operations/Bulk/BulkUpdateOperationTest.php
+++ b/tests/Unit/Operations/Bulk/BulkUpdateOperationTest.php
@@ -57,7 +57,7 @@ class BulkUpdateOperationTest extends TestCase
         ], $operation->build());
     }
 
-    public function iterableInputDataProvider(): \Generator
+    public static function iterableInputDataProvider(): \Generator
     {
         yield 'collection' => [collect([new TestModelWithoutSettings()])];
         yield 'array' => [[new TestModelWithoutSettings()]];

--- a/tests/Unit/ScoutSearchCommandBuilderTest.php
+++ b/tests/Unit/ScoutSearchCommandBuilderTest.php
@@ -102,7 +102,7 @@ class ScoutSearchCommandBuilderTest extends TestCase
         self::assertSame($expected, $command->$getter());
     }
 
-    public function buildCommandProvider(): array
+    public static function buildCommandProvider(): array
     {
         return [
             ['Must', [new Term('field', 'value')]],
@@ -140,44 +140,44 @@ class ScoutSearchCommandBuilderTest extends TestCase
 
         $command->setSort([new Sort('id', 'invalid')]);
     }
-    
+
     public function test_it_can_set_the_sort_order_as_array(): void
     {
         $command = new ScoutSearchCommandBuilder();
-        
+
         self::assertFalse($command->hasSort());
-        
+
         $command->setSort([new Sort('id')]);
-        
+
         self::assertTrue($command->hasSort());
         self::assertSame([['id' => 'asc']], $command->getSort());
-        
+
         $command->setSort([]);
-        
+
         self::assertFalse($command->hasSort());
         self::assertSame([], $command->getSort());
-        
+
         $command->setSort([new Sort('id', SortOrder::for('desc'))]);
-        
+
         self::assertTrue($command->hasSort());
         self::assertSame([['id' => ['missing' => '_last', 'order' => 'desc']]], $command->getSort());
-        
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected one of: "asc", "desc". Got: "invalid"');
-        
+
         $command->setSort([new Sort('id', SortOrder::for('invalid'))]);
     }
-    
+
     public function test_it_throws_exception_when_missing_is_invalid(): void
     {
         $command = new ScoutSearchCommandBuilder();
-        
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected one of: "_first", "_last". Got: "invalid"');
-        
+
         $command->setSort([new Sort('id', SortOrder::for('desc', 'invalid'))]);
     }
-    
+
     public function test_it_only_accepts_sort_classes(): void
     {
         $command = new ScoutSearchCommandBuilder();
@@ -289,7 +289,7 @@ class ScoutSearchCommandBuilderTest extends TestCase
         ];
 
         self::assertEquals($expectedQuery, $query);
-    }    
+    }
 
     public function test_it_has_bool_query_as_default_compound(): void
     {
@@ -443,7 +443,7 @@ class ScoutSearchCommandBuilderTest extends TestCase
         ];
 
         self::assertEquals($expectedQuery, $query);
-    }    
+    }
 
     public function test_it_wraps_scout_builder_query_properties(): void
     {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+include __DIR__ . '/../vendor/autoload.php';
+
+DG\BypassFinals::allowPaths([
+    '*/vendor/elasticsearch/*',
+]);
+DG\BypassFinals::enable(false);


### PR DESCRIPTION
This has one two breaking changes:

- You can only use elastic 8 with this code, the elastic client is not backwards compatible 
- The `selector` namespace has changed, I updated the docs as such.


TODO

- [x] Test it on an elastic 8 engine
- [x] Update changelog 
