### PR TITLE
Allow string value in Range syntax

### DIFF
--- a/src/Domain/Syntax/Range.php
+++ b/src/Domain/Syntax/Range.php
@@ -36,7 +36,10 @@ class Range implements SyntaxInterface
         foreach ($definitions as $key => $value) {
             Assert::inArray($key, self::RELATIONS);
             Assert::notNull($value);
-            Assert::numeric($value);
+            Assert::true(
+                is_numeric($value) || is_string($value),
+                sprintf('Expected one of: "string", "integer", "double". Got: %s', gettype($value))
+            ); 
         }
     }
 }

--- a/tests/Unit/Syntax/RangeTest.php
+++ b/tests/Unit/Syntax/RangeTest.php
@@ -91,6 +91,25 @@ class RangeTest extends TestCase
         self::assertSame($expected, $query);
     }
 
+    public function test_it_accepts_string_values(): void
+    {
+        $subject = new Range('rating', ['gte' => '2020-01-01T00:00:00', 'lte' => '2021-01-01T00:00:00']);
+
+        $expected = [
+            'range' => [
+                'rating' => [
+                    'gte' => '2020-01-01T00:00:00',
+                    'lte' => '2021-01-01T00:00:00',
+                    'boost' => 1.0,
+                ],
+            ]
+        ];
+
+        $query = $subject->build();
+
+        self::assertSame($expected, $query);
+    }
+
     public function test_it_accepts_only_one_value(): void
     {
         $subject = new Range('rating', ['gte' => -50.4]);
@@ -116,10 +135,10 @@ class RangeTest extends TestCase
         new Range('rating', ['gte' => 3.4, 'lte' => null]);
     }
 
-    public function test_it_stops_on_non_numeric_value(): void
+    public function test_it_stops_on_non_numeric_or_string_value(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected a numeric. Got: string');
-        new Range('rating', ['gte' => 3.4, 'lte' => '2d']);
+        $this->expectExceptionMessage('Expected one of: "string", "integer", "double". Got: array');
+        new Range('rating', ['gte' => 3.4, 'lte' => ['2.0']]);
     }
 }

--- a/tests/Unit/Syntax/RangeTest.php
+++ b/tests/Unit/Syntax/RangeTest.php
@@ -93,11 +93,11 @@ class RangeTest extends TestCase
 
     public function test_it_accepts_string_values(): void
     {
-        $subject = new Range('rating', ['gte' => '2020-01-01T00:00:00', 'lte' => '2021-01-01T00:00:00']);
+        $subject = new Range('date', ['gte' => '2020-01-01T00:00:00', 'lte' => '2021-01-01T00:00:00']);
 
         $expected = [
             'range' => [
-                'rating' => [
+                'date' => [
                     'gte' => '2020-01-01T00:00:00',
                     'lte' => '2021-01-01T00:00:00',
                     'boost' => 1.0,


### PR DESCRIPTION
Closes https://github.com/Jeroen-G/Explorer/issues/263

Changes:

- Allows strings for the range syntax, for [date comparison](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html#range-query-time-zone)
- Adds / updates tests
- Uses assert true to cover string / numeric, as I couldn't find an assertion that covered both out of the box.

To test this, you'll need to map a field to a date, you should then be able to do the range syntax - even using just the date ie `2025-03-28`

Any adjustments feel free to let me know 🫡 