### PR TITLE
Fixes Jeroen-G/Explorer#230

### DIFF
--- a/src/Domain/Syntax/Term.php
+++ b/src/Domain/Syntax/Term.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace JeroenG\Explorer\Domain\Syntax;
+use Webmozart\Assert\Assert;
 
 class Term implements SyntaxInterface
 {
@@ -14,6 +15,10 @@ class Term implements SyntaxInterface
 
     public function __construct(string $field, $value = null, ?float $boost = 1.0)
     {
+        // ES accepts scalars for term queries in practice (string|int|float|bool).
+        Assert::notNull($value, 'Term value must not be null.');
+        Assert::scalar($value, 'Term value must be a scalar (string|int|float|bool).');
+
         $this->field = $field;
         $this->value = $value;
         $this->boost = $boost;

--- a/src/Domain/Syntax/Terms.php
+++ b/src/Domain/Syntax/Terms.php
@@ -16,7 +16,10 @@ class Terms implements SyntaxInterface
 
     public function __construct(string $field, array $values = [], ?float $boost = 1.0)
     {
-        Assert::allStringNotEmpty($values);
+        // ES accepts scalars for term queries in practice (string|int|float|bool).
+        Assert::notEmpty($values, 'Terms values must not be empty.');
+        Assert::allNotNull($values, 'Terms values must not contain null.');
+        Assert::allScalar($values, 'Terms values must be scalars (string|int|float|bool).');
 
         $this->field = $field;
         $this->values = $values;

--- a/tests/Support/SyntaxProvider.php
+++ b/tests/Support/SyntaxProvider.php
@@ -12,15 +12,10 @@ trait SyntaxProvider
 {
     public static function syntaxProvider(): array
     {
-        return array_map(fn ($item) => [$item], self::getSyntaxClasses());
-    }
-
-    public static function getSyntaxClasses(): array
-    {
         return [
-            Matching::class,
-            Term::class,
-            MultiMatch::class
+            'matching'   => [Matching::class, ['testcase']],
+            'term'       => [Term::class, ['testcase', ':val:']],
+            'multimatch' => [MultiMatch::class, ['testcase']],
         ];
     }
 }

--- a/tests/Unit/Query/QueryTest.php
+++ b/tests/Unit/Query/QueryTest.php
@@ -122,7 +122,7 @@ final class QueryTest extends TestCase
         $this->query->addRescoring($rescoring1);
 
         $rescoring2 = new Rescoring();
-        $rescoring2->setQuery(new Term(':fld:'));
+        $rescoring2->setQuery(new Term(':fld:', ':val:'));
         $this->query->addRescoring($rescoring2);
 
         $result = $this->query->build();

--- a/tests/Unit/Syntax/Compound/BoolQueryTest.php
+++ b/tests/Unit/Syntax/Compound/BoolQueryTest.php
@@ -74,11 +74,12 @@ class BoolQueryTest extends TestCase
     /**
      * @dataProvider syntaxProvider
      * @param string $className
+     * @param array $args
      */
-    public function test_it_accepts_different_types_of_syntax(string $className): void
+    public function test_it_accepts_different_types_of_syntax(string $className, array $args): void
     {
         $subject = new BoolQuery();
-        $syntax = new $className('testcase');
+        $syntax = new $className(...$args);
 
         $subject->must($syntax);
 


### PR DESCRIPTION
The Elasticsearch [term query docs](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-term-query) describe field.value as a string, and the [terms query docs](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-terms-query) show values as arrays of strings. 

However, in practice ES accepts more than just strings, therefore I adjusted the assertions to reflect the actual behaviour.